### PR TITLE
feat: Implemented UI with TrailX design system

### DIFF
--- a/packages/app/src/components/CollapsedFooter/CollapsedFooter.module.css
+++ b/packages/app/src/components/CollapsedFooter/CollapsedFooter.module.css
@@ -1,0 +1,14 @@
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.625rem 1rem 0.75rem;
+  cursor: pointer;
+  flex-wrap: wrap;
+  animation: chipsIn 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes chipsIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}

--- a/packages/app/src/components/CollapsedFooter/CollapsedFooter.tsx
+++ b/packages/app/src/components/CollapsedFooter/CollapsedFooter.tsx
@@ -1,0 +1,51 @@
+import { Clock, Path, ArrowUp } from '@phosphor-icons/react'
+import type { RouteResult } from '@trailx/shared'
+import { Chip } from '../ui/Chip'
+import styles from './CollapsedFooter.module.css'
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  if (h > 0) return `${h}h ${m}m`
+  return `${m} min`
+}
+
+function formatDistance(meters: number): string {
+  if (meters >= 1000) return `${(meters / 1000).toFixed(1)} km`
+  return `${Math.round(meters)} m`
+}
+
+function computeGain(elevation: number[]): number {
+  return elevation.reduce(
+    (acc, v, i) => (i > 0 && v > elevation[i - 1] ? acc + (v - elevation[i - 1]) : acc),
+    0,
+  )
+}
+
+interface CollapsedFooterProps {
+  result: RouteResult
+  onClick?: () => void
+}
+
+export function CollapsedFooter({ result, onClick }: CollapsedFooterProps) {
+  const gain = computeGain(result.elevation)
+
+  return (
+    <div className={styles.row} onClick={onClick} role="button" tabIndex={0}>
+      <Chip
+        icon={<Clock size={12} weight="fill" />}
+        label={formatDuration(result.duration)}
+      />
+      <Chip
+        icon={<Path size={12} weight="fill" />}
+        label={formatDistance(result.distance)}
+      />
+      {gain > 0 && (
+        <Chip
+          icon={<ArrowUp size={12} weight="bold" />}
+          label={`+${Math.round(gain)} m`}
+        />
+      )}
+    </div>
+  )
+}

--- a/packages/app/src/components/ElevationBar/ElevationBar.module.css
+++ b/packages/app/src/components/ElevationBar/ElevationBar.module.css
@@ -1,0 +1,100 @@
+.bar {
+  background: var(--surface-variant);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  overflow: hidden;
+  pointer-events: all;
+  box-shadow: var(--shadow-overlay), 0 -2px 12px rgba(68, 86, 181, 0.06);
+  animation: slideUpBar 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes slideUpBar {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.expanded {
+  border-radius: var(--radius-lg);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.875rem;
+  gap: 0.75rem;
+}
+
+.label {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--secondary);
+  opacity: 0.7;
+}
+
+.chips {
+  display: flex;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+  flex: 1;
+}
+
+.controls {
+  display: flex;
+  gap: 0.125rem;
+  flex-shrink: 0;
+}
+
+.controlBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--primary);
+  opacity: 0.4;
+  cursor: pointer;
+  transition: opacity 0.12s ease, background 0.12s ease;
+}
+
+.controlBtn:hover {
+  opacity: 1;
+  background: rgba(68, 86, 181, 0.07);
+}
+
+.chart {
+  padding: 0 0.875rem 0.75rem;
+}
+
+.reopenBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  padding: 0.3rem 0.75rem;
+  background: var(--surface-variant);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--secondary);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  font-family: var(--font-family);
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  pointer-events: all;
+  box-shadow: var(--shadow-float);
+  transition: opacity 0.15s ease;
+  opacity: 0.7;
+}
+
+.reopenBtn:hover {
+  opacity: 1;
+}

--- a/packages/app/src/components/ElevationBar/ElevationBar.tsx
+++ b/packages/app/src/components/ElevationBar/ElevationBar.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react'
+import { CaretUp, CaretDown, X } from '@phosphor-icons/react'
+import { useMapStore } from '../../store/useMapStore'
+import { Chip } from '../ui/Chip'
+import { ElevationChart } from './ElevationChart'
+import styles from './ElevationBar.module.css'
+
+type ElevMode = 'compact' | 'expanded' | 'closed'
+
+function formatElevation(m: number): string {
+  return `${Math.round(m)} m`
+}
+
+function computeGain(elevation: number[]): number {
+  return elevation.reduce(
+    (acc, v, i) => (i > 0 && v > elevation[i - 1] ? acc + (v - elevation[i - 1]) : acc),
+    0,
+  )
+}
+
+export function ElevationBar() {
+  const routeResult = useMapStore((s) => s.routeResult)
+  const [mode, setMode] = useState<ElevMode>('compact')
+
+  if (!routeResult || routeResult.elevation.length === 0) return null
+
+  const { elevation } = routeResult
+  const minElev = Math.min(...elevation)
+  const maxElev = Math.max(...elevation)
+  const gain = computeGain(elevation)
+
+  if (mode === 'closed') {
+    return (
+      <button className={styles.reopenBtn} onClick={() => setMode('compact')} title="Show elevation">
+        <CaretUp size={14} />
+      </button>
+    )
+  }
+
+  return (
+    <div className={`${styles.bar} ${mode === 'expanded' ? styles.expanded : ''}`}>
+      <div className={styles.header}>
+        <span className={styles.label}>Elev.</span>
+        <div className={styles.chips}>
+          <Chip label={`+${formatElevation(gain)}`} title="Elevation gain" />
+          <Chip label={`${formatElevation(minElev)}`} title="Min elevation" />
+          <Chip label={`${formatElevation(maxElev)}`} title="Max elevation" />
+        </div>
+        <div className={styles.controls}>
+          <button
+            className={styles.controlBtn}
+            onClick={() => setMode(mode === 'expanded' ? 'compact' : 'expanded')}
+            title={mode === 'expanded' ? 'Collapse' : 'Expand'}
+          >
+            {mode === 'expanded' ? <CaretDown size={14} /> : <CaretUp size={14} />}
+          </button>
+          <button
+            className={styles.controlBtn}
+            onClick={() => setMode('closed')}
+            title="Close"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      </div>
+      {mode === 'expanded' && (
+        <div className={styles.chart}>
+          <ElevationChart elevation={elevation} height={80} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/app/src/components/ElevationBar/ElevationChart.tsx
+++ b/packages/app/src/components/ElevationBar/ElevationChart.tsx
@@ -1,0 +1,90 @@
+interface ElevationChartProps {
+  elevation: number[]
+  width?: number
+  height?: number
+}
+
+function downsample(arr: number[], maxPoints: number): number[] {
+  if (arr.length <= maxPoints) return arr
+  const stride = Math.ceil(arr.length / maxPoints)
+  return arr.filter((_, i) => i % stride === 0)
+}
+
+export function ElevationChart({ elevation, width = 400, height = 80 }: ElevationChartProps) {
+  const data = downsample(elevation, 200)
+  if (data.length < 2) return null
+
+  const min = Math.min(...data)
+  const max = Math.max(...data)
+  const range = max - min || 1
+
+  const PAD_TOP = 8
+  const PAD_BOTTOM = 4
+  const drawH = height - PAD_TOP - PAD_BOTTOM
+
+  const toY = (v: number) => PAD_TOP + drawH - ((v - min) / range) * drawH
+
+  const pts = data
+    .map((v, i) => `${((i / (data.length - 1)) * width).toFixed(1)},${toY(v).toFixed(1)}`)
+    .join(' ')
+
+  const fillPts = `0,${height} ${pts} ${width},${height}`
+
+  // Guide lines at 25%, 50%, 75% of the elevation range
+  const guides = [0.25, 0.5, 0.75].map((frac) => ({
+    y: toY(min + range * frac),
+    label: `${Math.round(min + range * frac)} m`,
+  }))
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      style={{ width: '100%', height: `${height}px`, display: 'block', overflow: 'visible' }}
+      aria-hidden
+    >
+      <defs>
+        <linearGradient id="elev-fill" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#4456b5" stopOpacity="0.22" />
+          <stop offset="70%" stopColor="#879afd" stopOpacity="0.08" />
+          <stop offset="100%" stopColor="#879afd" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+
+      {/* Guide lines */}
+      {guides.map(({ y }) => (
+        <line
+          key={y}
+          x1={0}
+          y1={y.toFixed(1)}
+          x2={width}
+          y2={y.toFixed(1)}
+          stroke="rgba(68, 86, 181, 0.12)"
+          strokeWidth="1"
+          strokeDasharray="3,4"
+        />
+      ))}
+
+      {/* Filled area */}
+      <polygon points={fillPts} fill="url(#elev-fill)" />
+
+      {/* Profile line */}
+      <polyline
+        points={pts}
+        fill="none"
+        stroke="#4456b5"
+        strokeWidth="1.75"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+
+      {/* Min/max tick labels */}
+      <text x="2" y={toY(max) - 3} fontSize="8" fill="rgba(68,86,181,0.5)" fontFamily="Space Grotesk, sans-serif">
+        {Math.round(max)} m
+      </text>
+      <text x="2" y={toY(min) + 10} fontSize="8" fill="rgba(68,86,181,0.5)" fontFamily="Space Grotesk, sans-serif">
+        {Math.round(min)} m
+      </text>
+    </svg>
+  )
+}

--- a/packages/app/src/components/ErrorMessage/ErrorMessage.module.css
+++ b/packages/app/src/components/ErrorMessage/ErrorMessage.module.css
@@ -1,0 +1,40 @@
+.banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  background: rgba(199, 57, 57, 0.08);
+  border-radius: var(--radius-md);
+  padding: 0.625rem 0.75rem;
+}
+
+.icon {
+  color: #c03535;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.text {
+  flex: 1;
+  font-size: 0.8125rem;
+  color: #c03535;
+  line-height: 1.45;
+}
+
+.dismiss {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0.125rem;
+  cursor: pointer;
+  color: #c03535;
+  opacity: 0.6;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  transition: opacity 0.15s ease;
+}
+
+.dismiss:hover {
+  opacity: 1;
+}

--- a/packages/app/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/packages/app/src/components/ErrorMessage/ErrorMessage.tsx
@@ -1,0 +1,24 @@
+import { X, WarningCircle } from '@phosphor-icons/react'
+import { useMapStore } from '../../store/useMapStore'
+import styles from './ErrorMessage.module.css'
+
+export function ErrorMessage() {
+  const routeError = useMapStore((s) => s.routeError)
+  const setRouteError = useMapStore((s) => s.actions.setRouteError)
+
+  if (!routeError) return null
+
+  return (
+    <div className={styles.banner} role="alert">
+      <WarningCircle size={16} weight="fill" className={styles.icon} />
+      <span className={styles.text}>{routeError}</span>
+      <button
+        className={styles.dismiss}
+        onClick={() => setRouteError(null)}
+        aria-label="Dismiss error"
+      >
+        <X size={14} weight="bold" />
+      </button>
+    </div>
+  )
+}

--- a/packages/app/src/components/MapControls/MapControls.module.css
+++ b/packages/app/src/components/MapControls/MapControls.module.css
@@ -1,0 +1,82 @@
+.controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.75rem;
+  gap: 0.5rem;
+  pointer-events: all;
+  animation: fadeInControls 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes fadeInControls {
+  from { opacity: 0; transform: translateX(10px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+/* Zoom group — stacked pill */
+.zoomGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--surface-variant);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-float), 0 4px 20px rgba(68, 86, 181, 0.08);
+  overflow: hidden;
+}
+
+.zoomDivider {
+  width: 22px;
+  height: 1px;
+  background: rgba(21, 20, 21, 0.1);
+}
+
+.btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: transparent;
+  color: var(--primary);
+  cursor: pointer;
+  transition: background 0.12s ease, transform 0.1s ease;
+  flex-shrink: 0;
+}
+
+.btn:hover {
+  background: rgba(68, 86, 181, 0.08);
+}
+
+.btn:active {
+  transform: scale(0.92);
+}
+
+/* Locate button — separate pill */
+.locateBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: var(--surface-variant);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  color: var(--secondary);
+  cursor: pointer;
+  box-shadow: var(--shadow-float), 0 4px 20px rgba(68, 86, 181, 0.08);
+  transition: background 0.12s ease, transform 0.15s ease;
+}
+
+.locateBtn:hover {
+  background: var(--secondary-container);
+  transform: scale(1.08);
+}
+
+.locateBtn:active {
+  transform: scale(0.95);
+}

--- a/packages/app/src/components/MapControls/MapControls.tsx
+++ b/packages/app/src/components/MapControls/MapControls.tsx
@@ -1,0 +1,45 @@
+import type { RefObject } from 'react'
+import { Plus, Minus, Crosshair } from '@phosphor-icons/react'
+import type { MapViewHandle } from '../MapView/MapView'
+import styles from './MapControls.module.css'
+
+interface MapControlsProps {
+  mapRef: RefObject<MapViewHandle | null>
+}
+
+export function MapControls({ mapRef }: MapControlsProps) {
+  const zoomIn = () => mapRef.current?.getMap()?.zoomIn()
+  const zoomOut = () => mapRef.current?.getMap()?.zoomOut()
+
+  const locate = () => {
+    navigator.geolocation?.getCurrentPosition(
+      (pos) => {
+        mapRef.current?.getMap()?.flyTo({
+          center: [pos.coords.longitude, pos.coords.latitude],
+          zoom: 14,
+        })
+      },
+      () => {},
+    )
+  }
+
+  return (
+    <div className={styles.controls}>
+      {/* Zoom — stacked pill */}
+      <div className={styles.zoomGroup}>
+        <button className={styles.btn} onClick={zoomIn} aria-label="Zoom in">
+          <Plus size={17} weight="bold" />
+        </button>
+        <div className={styles.zoomDivider} />
+        <button className={styles.btn} onClick={zoomOut} aria-label="Zoom out">
+          <Minus size={17} weight="bold" />
+        </button>
+      </div>
+
+      {/* Locate — separate pill */}
+      <button className={styles.locateBtn} onClick={locate} aria-label="My location">
+        <Crosshair size={17} weight="bold" />
+      </button>
+    </div>
+  )
+}

--- a/packages/app/src/components/MapView/MapView.module.css
+++ b/packages/app/src/components/MapView/MapView.module.css
@@ -4,44 +4,56 @@
   position: relative;
 }
 
-/* ── Waypoint markers (applied to imperative DOM elements) ── */
+/* ── Waypoint markers — map-pin shape ────────────────────────────────────
+   Rotated rounded-square gives the classic teardrop pin silhouette.
+   Applied to imperative DOM elements created in MapView.tsx.
+──────────────────────────────────────────────────────────────────────────── */
 .marker {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
+  width: 32px;
+  height: 38px;
+  position: relative;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  border: 2px solid rgba(255, 255, 255, 0.85);
-  box-shadow: 0 2px 8px rgba(29, 27, 24, 0.28);
+  padding-top: 5px;
   cursor: pointer;
-  font-family: var(--font-family, 'Space Grotesk', system-ui, sans-serif);
-  font-size: 11px;
-  font-weight: 700;
-  color: #ffffff;
   user-select: none;
-  transition: transform 0.12s ease;
+  transition: transform 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+  filter: drop-shadow(0 3px 8px rgba(29, 27, 24, 0.3));
 }
 
 .marker:hover {
-  transform: scale(1.15);
+  transform: scale(1.2) translateY(-3px);
 }
 
-.start {
-  background-color: #27ae60;
+/* Pin body: rotated rounded square = teardrop */
+.marker::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%) rotate(-45deg);
+  width: 26px;
+  height: 26px;
+  border-radius: 50% 50% 50% 0;
+  background: currentColor;
+  border: 2.5px solid rgba(255, 255, 255, 0.9);
 }
 
-.end {
-  background-color: #e74c3c;
-}
-
-.intermediate {
-  background-color: #2481cc;
-}
+.start        { color: #2a8f4a; }
+.end          { color: #c0392b; }
+.intermediate { color: #4456b5; }
 
 .markerLabel {
+  position: relative;
+  z-index: 1;
   line-height: 1;
   pointer-events: none;
+  font-family: var(--font-family, 'Space Grotesk', system-ui, sans-serif);
+  font-size: 10px;
+  font-weight: 700;
+  color: #ffffff;
+  margin-top: 2px;
 }
 
 /* ── Routing spinner overlay ─────────────────────────────────────────────── */
@@ -54,56 +66,35 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  background-color: var(--surface-variant, rgba(242, 237, 231, 0.7));
+  background: var(--surface-variant, rgba(242, 237, 231, 0.75));
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border-radius: var(--radius-full, 9999px);
-  padding: 0.375rem 0.875rem;
+  padding: 0.4rem 1rem;
   font-size: 0.8125rem;
   font-weight: 500;
   color: var(--primary, #151415);
   pointer-events: none;
+  letter-spacing: 0.01em;
+  box-shadow: 0 2px 16px rgba(68, 86, 181, 0.12);
+  animation: fadeInDown 0.2s ease;
+}
+
+@keyframes fadeInDown {
+  from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
 
 .spinner {
   width: 14px;
   height: 14px;
-  border: 2px solid rgba(21, 20, 21, 0.2);
-  border-top-color: var(--primary, #151415);
+  border: 2px solid rgba(68, 86, 181, 0.2);
+  border-top-color: var(--secondary, #4456b5);
   border-radius: 50%;
-  animation: spin 0.7s linear infinite;
+  animation: spin 0.65s linear infinite;
   flex-shrink: 0;
 }
 
 @keyframes spin {
   to { transform: rotate(360deg); }
-}
-
-/* ── Rate-limit toast ────────────────────────────────────────────────────── */
-.toast {
-  position: absolute;
-  bottom: 80px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 30;
-  background-color: var(--primary-container, #2a2829);
-  color: #ffffff;
-  border-radius: var(--radius-md, 0.5rem);
-  padding: 0.625rem 1rem;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  white-space: nowrap;
-  max-width: calc(100% - 2rem);
-  text-align: center;
-  animation: fadeInUp 0.25s ease, fadeOut 0.35s ease 3.65s forwards;
-  pointer-events: none;
-}
-
-@keyframes fadeInUp {
-  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0);   }
-}
-
-@keyframes fadeOut {
-  to { opacity: 0; }
 }

--- a/packages/app/src/components/MapView/MapView.tsx
+++ b/packages/app/src/components/MapView/MapView.tsx
@@ -39,7 +39,6 @@ export const MapView = forwardRef<MapViewHandle>(function MapView(_props, ref) {
   const mapRef = useRef<maplibregl.Map | null>(null)
   const markersRef = useRef<Map<string, maplibregl.Marker>>(new Map())
   const [mapReady, setMapReady] = useState(false)
-  const [showRateLimit, setShowRateLimit] = useState(false)
 
   const waypoints = useMapStore((s) => s.waypoints)
   const routeResult = useMapStore((s) => s.routeResult)
@@ -51,16 +50,6 @@ export const MapView = forwardRef<MapViewHandle>(function MapView(_props, ref) {
   useEffect(() => { addWaypointRef.current = addWaypoint }, [addWaypoint])
 
   useImperativeHandle(ref, () => ({ getMap: () => mapRef.current }))
-
-  // ── Rate-limit toast ──────────────────────────────────────────────────────
-  useEffect(() => {
-    const handler = () => {
-      setShowRateLimit(true)
-      setTimeout(() => setShowRateLimit(false), 4000)
-    }
-    window.addEventListener('trailx:ratelimit', handler)
-    return () => window.removeEventListener('trailx:ratelimit', handler)
-  }, [])
 
   // ── Map initialisation ────────────────────────────────────────────────────
   useEffect(() => {
@@ -88,9 +77,9 @@ export const MapView = forwardRef<MapViewHandle>(function MapView(_props, ref) {
         source: ROUTE_SOURCE,
         layout: { 'line-join': 'round', 'line-cap': 'round' },
         paint: {
-          'line-color': '#2481cc',
-          'line-width': 4,
-          'line-opacity': 0.85,
+          'line-color': '#4456b5',
+          'line-width': 5,
+          'line-opacity': 0.9,
         },
       })
 
@@ -170,12 +159,7 @@ export const MapView = forwardRef<MapViewHandle>(function MapView(_props, ref) {
       {isRouting && (
         <div className={styles.spinnerOverlay}>
           <span className={styles.spinner} />
-          Строю маршрут…
-        </div>
-      )}
-      {showRateLimit && (
-        <div className={styles.toast}>
-          Лимит GraphHopper исчерпан. Введите свой API ключ.
+          Building route…
         </div>
       )}
     </div>

--- a/packages/app/src/components/MobileHeader/MobileHeader.module.css
+++ b/packages/app/src/components/MobileHeader/MobileHeader.module.css
@@ -1,0 +1,55 @@
+.bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.625rem 0.75rem;
+  padding: 0.625rem 1rem;
+  background: var(--surface-variant);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-float), 0 4px 24px rgba(68, 86, 181, 0.07);
+  pointer-events: all;
+  animation: slideDownBar 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes slideDownBar {
+  from { opacity: 0; transform: translateY(-10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.profileIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: var(--secondary-container);
+  border-radius: var(--radius-full);
+  color: var(--on-secondary-container);
+  flex-shrink: 0;
+}
+
+.inputs {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.inputLine {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0.7;
+}
+
+.divider {
+  height: 1px;
+  background: linear-gradient(to right, transparent, rgba(68, 86, 181, 0.18), transparent);
+  margin: 0.2rem 0;
+}

--- a/packages/app/src/components/MobileHeader/MobileHeader.tsx
+++ b/packages/app/src/components/MobileHeader/MobileHeader.tsx
@@ -1,0 +1,33 @@
+import { Bicycle, Lightning, PersonSimpleWalk } from '@phosphor-icons/react'
+import type { RoutingProfile } from '@trailx/shared'
+import { useMapStore } from '../../store/useMapStore'
+import { useProfile } from '../../hooks/useProfile'
+import styles from './MobileHeader.module.css'
+
+const PROFILE_ICONS: Record<RoutingProfile, typeof Bicycle> = {
+  bike: Bicycle,
+  racingbike: Lightning,
+  foot: PersonSimpleWalk,
+}
+
+export function MobileHeader() {
+  const { profile } = useProfile()
+  const waypoints = useMapStore((s) => s.waypoints)
+
+  const ProfileIcon = PROFILE_ICONS[profile]
+  const start = waypoints[0]?.label ?? 'Choose starting point'
+  const end = waypoints[waypoints.length - 1]?.label ?? 'Choose destination'
+
+  return (
+    <div className={styles.bar}>
+      <div className={styles.profileIcon}>
+        <ProfileIcon size={20} weight="fill" />
+      </div>
+      <div className={styles.inputs}>
+        <span className={styles.inputLine} title={start}>{start}</span>
+        <div className={styles.divider} />
+        <span className={styles.inputLine} title={end}>{end}</span>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/components/PoweredBy/PoweredBy.tsx
+++ b/packages/app/src/components/PoweredBy/PoweredBy.tsx
@@ -1,0 +1,16 @@
+export function PoweredBy() {
+  return (
+    <p
+      style={{
+        fontSize: '0.6875rem',
+        color: 'var(--primary)',
+        opacity: 0.35,
+        textAlign: 'center',
+        padding: '0.25rem 0',
+        fontFamily: 'var(--font-family)',
+      }}
+    >
+      Routing by GraphHopper · Map © OpenStreetMap
+    </p>
+  )
+}

--- a/packages/app/src/components/ProfileTabs/ProfileTabs.module.css
+++ b/packages/app/src/components/ProfileTabs/ProfileTabs.module.css
@@ -1,0 +1,37 @@
+.row {
+  display: flex;
+  gap: 0.25rem;
+  background: var(--surface-container);
+  border-radius: var(--radius-full);
+  padding: 0.25rem;
+  width: fit-content;
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 36px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--primary);
+  cursor: pointer;
+  opacity: 0.45;
+  transform: scale(1);
+  transition: opacity 0.18s ease, background 0.18s ease, transform 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.tab:hover {
+  opacity: 0.75;
+  transform: scale(1.05);
+}
+
+.tab.active {
+  background: var(--secondary-container);
+  color: var(--on-secondary-container);
+  opacity: 1;
+  transform: scale(1.08);
+  box-shadow: 0 2px 8px rgba(68, 86, 181, 0.18);
+}

--- a/packages/app/src/components/ProfileTabs/ProfileTabs.tsx
+++ b/packages/app/src/components/ProfileTabs/ProfileTabs.tsx
@@ -1,0 +1,32 @@
+import { Bicycle, Lightning, PersonSimpleWalk } from '@phosphor-icons/react'
+import type { RoutingProfile } from '@trailx/shared'
+import { useProfile } from '../../hooks/useProfile'
+import styles from './ProfileTabs.module.css'
+
+const PROFILES: { value: RoutingProfile; icon: typeof Bicycle; label: string }[] = [
+  { value: 'bike', icon: Bicycle, label: 'Bike' },
+  { value: 'racingbike', icon: Lightning, label: 'Racing' },
+  { value: 'foot', icon: PersonSimpleWalk, label: 'Walk' },
+]
+
+export function ProfileTabs() {
+  const { profile, setProfile } = useProfile()
+
+  return (
+    <div className={styles.row} role="tablist" aria-label="Routing profile">
+      {PROFILES.map(({ value, icon: Icon, label }) => (
+        <button
+          key={value}
+          role="tab"
+          aria-selected={profile === value}
+          aria-label={label}
+          title={label}
+          className={`${styles.tab} ${profile === value ? styles.active : ''}`}
+          onClick={() => setProfile(value)}
+        >
+          <Icon size={20} weight={profile === value ? 'fill' : 'regular'} />
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/packages/app/src/components/RouteResults/RouteResults.module.css
+++ b/packages/app/src/components/RouteResults/RouteResults.module.css
@@ -1,0 +1,40 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--primary);
+  opacity: 0.4;
+  padding: 0 0.25rem;
+}
+
+.card {
+  background: var(--surface-container-high);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 0.875rem 0.75rem 0.75rem;
+  border-left: 2.5px solid var(--secondary);
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+  animation: fadeSlideIn 0.25s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes fadeSlideIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.card:hover {
+  background: var(--surface-container-high);
+  box-shadow: 0 2px 12px rgba(68, 86, 181, 0.09);
+}
+
+.chips {
+  display: flex;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}

--- a/packages/app/src/components/RouteResults/RouteResults.tsx
+++ b/packages/app/src/components/RouteResults/RouteResults.tsx
@@ -1,0 +1,58 @@
+import { Clock, Path, ArrowUp } from '@phosphor-icons/react'
+import type { RouteResult } from '@trailx/shared'
+import { Chip } from '../ui/Chip'
+import styles from './RouteResults.module.css'
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  if (h > 0) return `${h}h ${m}m`
+  return `${m} min`
+}
+
+function formatDistance(meters: number): string {
+  if (meters >= 1000) return `${(meters / 1000).toFixed(1)} km`
+  return `${Math.round(meters)} m`
+}
+
+function computeGain(elevation: number[]): number {
+  return elevation.reduce(
+    (acc, v, i) => (i > 0 && v > elevation[i - 1] ? acc + (v - elevation[i - 1]) : acc),
+    0,
+  )
+}
+
+interface RouteResultsProps {
+  result: RouteResult
+}
+
+export function RouteResults({ result }: RouteResultsProps) {
+  const gain = computeGain(result.elevation)
+
+  return (
+    <div className={styles.wrapper}>
+      <p className={styles.label}>Route</p>
+      <div className={styles.card}>
+        <div className={styles.chips}>
+          <Chip
+            icon={<Clock size={12} weight="fill" />}
+            label={formatDuration(result.duration)}
+            title="Duration"
+          />
+          <Chip
+            icon={<Path size={12} weight="fill" />}
+            label={formatDistance(result.distance)}
+            title="Distance"
+          />
+          {gain > 0 && (
+            <Chip
+              icon={<ArrowUp size={12} weight="bold" />}
+              label={`+${Math.round(gain)} m`}
+              title="Elevation gain"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/components/SearchSuggestions/SearchSuggestions.module.css
+++ b/packages/app/src/components/SearchSuggestions/SearchSuggestions.module.css
@@ -1,0 +1,52 @@
+.list {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 50;
+  list-style: none;
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-float), 0 8px 32px rgba(29, 27, 24, 0.1);
+  overflow: hidden;
+  max-height: 240px;
+  overflow-y: auto;
+  animation: dropIn 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+  transform-origin: top center;
+}
+
+@keyframes dropIn {
+  from { opacity: 0; transform: scaleY(0.92) translateY(-4px); }
+  to   { opacity: 1; transform: scaleY(1) translateY(0); }
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.625rem 0.875rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-family);
+  font-size: 0.8125rem;
+  color: var(--primary);
+  transition: background 0.1s ease;
+}
+
+.item:hover {
+  background: var(--surface-container);
+}
+
+.icon {
+  color: var(--secondary);
+  flex-shrink: 0;
+}
+
+.label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/app/src/components/SearchSuggestions/SearchSuggestions.tsx
+++ b/packages/app/src/components/SearchSuggestions/SearchSuggestions.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react'
+import type { PhotonFeature } from '../../services/photon'
+import { photonFeatureLabel } from '../../services/photon'
+import { MapPin } from '@phosphor-icons/react'
+import styles from './SearchSuggestions.module.css'
+
+interface SearchSuggestionsProps {
+  suggestions: PhotonFeature[]
+  onSelect: (feature: PhotonFeature) => void
+  onClose: () => void
+}
+
+export function SearchSuggestions({ suggestions, onSelect, onClose }: SearchSuggestionsProps) {
+  const ref = useRef<HTMLUListElement>(null)
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    const keyHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('mousedown', handler)
+    document.addEventListener('keydown', keyHandler)
+    return () => {
+      document.removeEventListener('mousedown', handler)
+      document.removeEventListener('keydown', keyHandler)
+    }
+  }, [onClose])
+
+  if (suggestions.length === 0) return null
+
+  return (
+    <ul ref={ref} className={styles.list} role="listbox">
+      {suggestions.map((feature, i) => {
+        const label = photonFeatureLabel(feature)
+        return (
+          <li key={i} role="option">
+            <button
+              className={styles.item}
+              onMouseDown={(e) => {
+                e.preventDefault() // prevent input blur before click registers
+                onSelect(feature)
+              }}
+            >
+              <MapPin size={14} weight="fill" className={styles.icon} />
+              <span className={styles.label}>{label}</span>
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/packages/app/src/components/Sidebar/Sidebar.module.css
+++ b/packages/app/src/components/Sidebar/Sidebar.module.css
@@ -1,0 +1,176 @@
+/* ── Floating card ──────────────────────────────────────────────────────── */
+.card {
+  position: relative;
+  margin: 0.75rem;
+  background: var(--surface-variant);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-float), 0 8px 48px rgba(68, 86, 181, 0.08);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 1.5rem);
+  pointer-events: all;
+  overflow: hidden;
+  animation: slideInCard 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes slideInCard {
+  from {
+    opacity: 0;
+    transform: translateX(-18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* ── Brand header ───────────────────────────────────────────────────────── */
+.brandHeader {
+  position: relative;
+  padding: 1.125rem 1rem 0.875rem;
+  background: linear-gradient(160deg, rgba(68, 86, 181, 0.09) 0%, transparent 65%);
+  overflow: hidden;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+/* Topographic contour pattern */
+.brandTopoPattern {
+  position: absolute;
+  inset: 0;
+  background-image:
+    repeating-radial-gradient(
+      ellipse 140% 100% at 110% 130%,
+      transparent 0px,
+      transparent 14px,
+      rgba(68, 86, 181, 0.055) 14px,
+      rgba(68, 86, 181, 0.055) 15px
+    ),
+    repeating-radial-gradient(
+      ellipse 120% 80% at 115% 140%,
+      transparent 0px,
+      transparent 24px,
+      rgba(68, 86, 181, 0.035) 24px,
+      rgba(68, 86, 181, 0.035) 25px
+    );
+  pointer-events: none;
+}
+
+.brandName {
+  font-size: 1.375rem;
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  color: var(--primary);
+  line-height: 1;
+  position: relative;
+}
+
+.brandTagline {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--secondary);
+  opacity: 0.75;
+  position: relative;
+}
+
+/* ── Section labels ─────────────────────────────────────────────────────── */
+.sectionLabel {
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--primary);
+  opacity: 0.35;
+  margin-bottom: 0.5rem;
+}
+
+/* ── Scroll area ────────────────────────────────────────────────────────── */
+.scroll {
+  flex: 1;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.875rem 0.875rem 0.75rem;
+}
+
+/* Subtle scrollbar */
+.scroll::-webkit-scrollbar {
+  width: 3px;
+}
+.scroll::-webkit-scrollbar-thumb {
+  background: rgba(68, 86, 181, 0.2);
+  border-radius: 2px;
+}
+
+.section {
+  padding: 0.375rem 0;
+}
+
+.footer {
+  margin-top: auto;
+  padding-top: 0.75rem;
+}
+
+/* ── Close button ───────────────────────────────────────────────────────── */
+.closeBtn {
+  position: absolute;
+  top: 0.875rem;
+  right: 0.875rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  background: rgba(21, 20, 21, 0.06);
+  border: none;
+  cursor: pointer;
+  color: var(--primary);
+  opacity: 0.5;
+  border-radius: var(--radius-full);
+  transition: opacity 0.15s ease, background 0.15s ease;
+  z-index: 1;
+}
+
+.closeBtn:hover {
+  opacity: 1;
+  background: rgba(21, 20, 21, 0.1);
+}
+
+/* ── Hamburger (when closed) ────────────────────────────────────────────── */
+.hamburger {
+  margin: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  background: var(--surface-variant);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: none;
+  border-radius: var(--radius-full);
+  color: var(--primary);
+  cursor: pointer;
+  box-shadow: var(--shadow-float);
+  pointer-events: all;
+  transition: background 0.15s ease, transform 0.15s ease;
+  animation: popIn 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes popIn {
+  from { opacity: 0; transform: scale(0.8); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.hamburger:hover {
+  background: var(--surface-container-high);
+  transform: scale(1.05);
+}

--- a/packages/app/src/components/Sidebar/Sidebar.tsx
+++ b/packages/app/src/components/Sidebar/Sidebar.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+import { List, X } from '@phosphor-icons/react'
+import { useMapStore } from '../../store/useMapStore'
+import { ProfileTabs } from '../ProfileTabs/ProfileTabs'
+import { WaypointInputList } from '../WaypointInputList/WaypointInputList'
+import { RouteResults } from '../RouteResults/RouteResults'
+import { ErrorMessage } from '../ErrorMessage/ErrorMessage'
+import { PoweredBy } from '../PoweredBy/PoweredBy'
+import styles from './Sidebar.module.css'
+
+export function Sidebar() {
+  const [open, setOpen] = useState(true)
+  const routeResult = useMapStore((s) => s.routeResult)
+
+  if (!open) {
+    return (
+      <button
+        className={styles.hamburger}
+        onClick={() => setOpen(true)}
+        aria-label="Open sidebar"
+      >
+        <List size={22} weight="regular" />
+      </button>
+    )
+  }
+
+  return (
+    <div className={styles.card}>
+      {/* Brand header with topographic texture */}
+      <div className={styles.brandHeader}>
+        <div className={styles.brandTopoPattern} aria-hidden />
+        <span className={styles.brandName}>TrailX</span>
+        <span className={styles.brandTagline}>Route Planner</span>
+        <button
+          className={styles.closeBtn}
+          onClick={() => setOpen(false)}
+          aria-label="Close sidebar"
+        >
+          <X size={15} weight="regular" />
+        </button>
+      </div>
+
+      <div className={styles.scroll}>
+        <div className={styles.section}>
+          <p className={styles.sectionLabel}>Transport</p>
+          <ProfileTabs />
+        </div>
+
+        <div className={styles.section}>
+          <p className={styles.sectionLabel}>Waypoints</p>
+          <WaypointInputList />
+        </div>
+
+        <ErrorMessage />
+
+        {routeResult && (
+          <div className={styles.section}>
+            <RouteResults result={routeResult} />
+          </div>
+        )}
+
+        <div className={styles.footer}>
+          <PoweredBy />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/components/WaypointInput/WaypointInput.module.css
+++ b/packages/app/src/components/WaypointInput/WaypointInput.module.css
@@ -1,0 +1,104 @@
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--surface-container-high);
+  border-radius: var(--radius-md);
+  padding: 0.5rem 0.625rem;
+  margin-bottom: 0.375rem;
+  position: relative;
+  z-index: 1; /* sit above the connector line */
+  transition: background 0.12s ease, box-shadow 0.12s ease;
+}
+
+.row:hover {
+  background: var(--surface-container-high);
+  box-shadow: 0 2px 8px rgba(68, 86, 181, 0.07);
+}
+
+.row:last-child {
+  margin-bottom: 0;
+}
+
+.dragHandle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: grab;
+  color: var(--primary);
+  opacity: 0.25;
+  flex-shrink: 0;
+  touch-action: none;
+  transition: opacity 0.12s ease;
+}
+
+.dragHandle:hover {
+  opacity: 0.6;
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+}
+
+/* Colored dot indicates waypoint type */
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 1.5px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.inputWrapper {
+  flex: 1;
+  position: relative;
+  min-width: 0;
+}
+
+.input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-family: var(--font-family);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--primary);
+  padding: 0;
+  min-width: 0;
+}
+
+.input:focus {
+  outline: none;
+}
+
+.input::placeholder {
+  color: var(--primary);
+  opacity: 0.28;
+  font-weight: 400;
+  letter-spacing: 0.01em;
+}
+
+.removeBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0.25rem;
+  cursor: pointer;
+  color: var(--primary);
+  opacity: 0.2;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  transition: opacity 0.15s ease, color 0.15s ease;
+}
+
+.removeBtn:hover {
+  opacity: 0.9;
+  color: #c03535;
+}

--- a/packages/app/src/components/WaypointInput/WaypointInput.tsx
+++ b/packages/app/src/components/WaypointInput/WaypointInput.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import { DotsSixVertical, X } from '@phosphor-icons/react'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import type { RoutePoint } from '@trailx/shared'
+import type { PhotonFeature } from '../../services/photon'
+import { photonFeatureLabel } from '../../services/photon'
+import { usePhotonSearch } from '../../hooks/usePhotonSearch'
+import { SearchSuggestions } from '../SearchSuggestions/SearchSuggestions'
+import styles from './WaypointInput.module.css'
+
+interface WaypointInputProps {
+  point: RoutePoint
+  placeholder: string
+  onRemove: (id: string) => void
+  onSelect: (id: string, lat: number, lng: number, label: string) => void
+}
+
+const TYPE_COLORS: Record<RoutePoint['type'], string> = {
+  start: '#27ae60',
+  end: '#e74c3c',
+  intermediate: '#4456b5',
+}
+
+export function WaypointInput({ point, placeholder, onRemove, onSelect }: WaypointInputProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: point.id })
+
+  const displayLabel = point.label ?? `${point.lat.toFixed(4)}, ${point.lng.toFixed(4)}`
+  const [inputValue, setInputValue] = useState(displayLabel)
+  const [showSuggestions, setShowSuggestions] = useState(false)
+
+  const { suggestions } = usePhotonSearch(showSuggestions ? inputValue : '')
+
+  const handleSelect = (feature: PhotonFeature) => {
+    const label = photonFeatureLabel(feature)
+    const [lng, lat] = feature.geometry.coordinates
+    setInputValue(label)
+    setShowSuggestions(false)
+    onSelect(point.id, lat, lng, label)
+  }
+
+  return (
+    <li
+      ref={setNodeRef}
+      className={styles.row}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.45 : 1,
+      }}
+    >
+      <button
+        className={styles.dragHandle}
+        aria-label="Drag to reorder"
+        {...attributes}
+        {...listeners}
+      >
+        <DotsSixVertical size={18} weight="regular" />
+      </button>
+
+      <span
+        className={styles.dot}
+        style={{ background: TYPE_COLORS[point.type] }}
+      />
+
+      <div className={styles.inputWrapper}>
+        <input
+          type="text"
+          className={styles.input}
+          value={inputValue}
+          placeholder={placeholder}
+          onChange={(e) => {
+            setInputValue(e.target.value)
+            setShowSuggestions(true)
+          }}
+          onFocus={() => setShowSuggestions(true)}
+          onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+        />
+        {showSuggestions && suggestions.length > 0 && (
+          <SearchSuggestions
+            suggestions={suggestions}
+            onSelect={handleSelect}
+            onClose={() => setShowSuggestions(false)}
+          />
+        )}
+      </div>
+
+      <button
+        className={styles.removeBtn}
+        onClick={() => onRemove(point.id)}
+        aria-label="Remove waypoint"
+      >
+        <X size={16} weight="bold" />
+      </button>
+    </li>
+  )
+}

--- a/packages/app/src/components/WaypointInputList/WaypointInputList.module.css
+++ b/packages/app/src/components/WaypointInputList/WaypointInputList.module.css
@@ -1,0 +1,51 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  position: relative;
+}
+
+/* Vertical connector line — runs through the dot column of each item */
+.list::before {
+  content: '';
+  position: absolute;
+  /* 18px drag handle + 0.5rem gap + half-dot width (5px) ≈ left: 30px */
+  left: 30px;
+  top: 20px;
+  bottom: 20px;
+  width: 1.5px;
+  background: linear-gradient(
+    to bottom,
+    #2a8f4a 0%,
+    rgba(68, 86, 181, 0.4) 50%,
+    #c0392b 100%
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Only show connector line when there are at least 2 items */
+.list:has(li:nth-child(2))::before {
+  display: block;
+}
+
+/* Hide line when only 1 item */
+.list:not(:has(li:nth-child(2)))::before {
+  display: none;
+}
+
+.hint {
+  font-size: 0.8125rem;
+  color: var(--primary);
+  opacity: 0.4;
+  text-align: center;
+  padding: 0.875rem 0;
+  letter-spacing: 0.01em;
+}

--- a/packages/app/src/components/WaypointInputList/WaypointInputList.tsx
+++ b/packages/app/src/components/WaypointInputList/WaypointInputList.tsx
@@ -1,0 +1,87 @@
+import { useCallback } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import type { DragEndEvent } from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable'
+import { WaypointInput } from '../WaypointInput/WaypointInput'
+import { useMapStore } from '../../store/useMapStore'
+import { useRoute } from '../../hooks/useRoute'
+import styles from './WaypointInputList.module.css'
+
+const PLACEHOLDERS: Record<string, string> = {
+  start: 'Choose starting point',
+  intermediate: 'Add stop',
+  end: 'Choose destination',
+}
+
+export function WaypointInputList() {
+  const { waypoints, removeWaypoint, reorderWaypoints } = useRoute()
+  const { addWaypoint } = useMapStore((s) => s.actions)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+      const from = waypoints.findIndex((p) => p.id === active.id)
+      const to = waypoints.findIndex((p) => p.id === over.id)
+      if (from !== -1 && to !== -1) reorderWaypoints(from, to)
+    },
+    [waypoints, reorderWaypoints],
+  )
+
+  const handleSelect = useCallback(
+    (id: string, lat: number, lng: number, label: string) => {
+      const point = waypoints.find((p) => p.id === id)
+      if (!point) return
+      // Remove old, re-add with new coords — keeps order/type via store
+      removeWaypoint(id)
+      addWaypoint({ ...point, lat, lng, label })
+    },
+    [waypoints, removeWaypoint, addWaypoint],
+  )
+
+  const ids = waypoints.map((p) => p.id)
+
+  return (
+    <div className={styles.wrapper}>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+          <ul className={styles.list}>
+            {waypoints.map((point) => (
+              <WaypointInput
+                key={point.id}
+                point={point}
+                placeholder={PLACEHOLDERS[point.type] ?? 'Add stop'}
+                onRemove={removeWaypoint}
+                onSelect={handleSelect}
+              />
+            ))}
+          </ul>
+        </SortableContext>
+      </DndContext>
+
+      {waypoints.length === 0 && (
+        <p className={styles.hint}>Click the map to add waypoints</p>
+      )}
+    </div>
+  )
+}

--- a/packages/app/src/components/shell/AppShell.module.css
+++ b/packages/app/src/components/shell/AppShell.module.css
@@ -1,33 +1,109 @@
-.shell {
+/* ═══════════════════════════════════════════════════════════
+   Desktop — 3-column CSS Grid matching GraphHopper Maps layout
+   Columns: sidebar (26rem) | map (1fr) | controls (auto)
+   Rows:    main (1fr) | elevation (auto)
+   Map layer sits behind everything via position:absolute
+═══════════════════════════════════════════════════════════ */
+
+.desktopGrid {
   position: relative;
   width: 100%;
   height: 100%;
+  display: grid;
+  grid-template-columns: var(--sidebar-width) 1fr auto;
+  grid-template-rows: 1fr auto;
   overflow: hidden;
 }
 
-/* ── Desktop ────────────────────────────────── */
-.desktop {
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  height: 100%;
-}
-
-.desktopMap {
-  flex: 1;
-  position: relative;
-  min-width: 0;
-  height: 100%;
-}
-
-/* ── Mobile / TMA ───────────────────────────── */
-.mobile {
-  position: relative;
-  width: 100%;
-  height: 100%;
-}
-
-.mobileMap {
+/* Full-bleed map background — behind all overlay columns */
+.mapLayer {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
   position: absolute;
   inset: 0;
+  z-index: 0;
+}
+
+/* Left column: sidebar floating over map */
+.sidebarCol {
+  grid-column: 1;
+  grid-row: 1;
+  z-index: 10;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+/* Center column: transparent (map shows through) */
+.centerCol {
+  grid-column: 2;
+  grid-row: 1;
+  pointer-events: none;
+}
+
+/* Right column: map controls */
+.controlsCol {
+  grid-column: 3;
+  grid-row: 1;
+  z-index: 10;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+/* Bottom row: elevation bar under the left column */
+.elevationRow {
+  grid-column: 1;
+  grid-row: 2;
+  z-index: 20;
+  pointer-events: none;
+  padding: 0 0.75rem 0.75rem;
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Mobile — Grid rows: top-bar | spacer | map | bottom-sheet
+═══════════════════════════════════════════════════════════ */
+
+.mobileGrid {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  grid-template-columns: 100%;
+  grid-template-rows: auto 0 1fr auto;
+  overflow: hidden;
+}
+
+.mobileTopRow {
+  grid-row: 1;
+  grid-column: 1;
+  z-index: 20;
+  pointer-events: none;
+}
+
+/* Row 3: map */
+.mobileMapRow {
+  grid-row: 3;
+  grid-column: 1;
+  position: relative;
+  z-index: 0;
+}
+
+/* Floating map controls overlay on mobile */
+.mobileControls {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 10;
+  pointer-events: none;
+}
+
+/* Row 4: bottom sheet container */
+.mobileBottomRow {
+  grid-row: 4;
+  grid-column: 1;
+  position: relative;
+  z-index: 10;
 }

--- a/packages/app/src/components/shell/AppShell.tsx
+++ b/packages/app/src/components/shell/AppShell.tsx
@@ -1,32 +1,71 @@
+import { useRef } from 'react'
 import { usePlatform } from '../../hooks/usePlatform'
 import { MapView } from '../MapView/MapView'
-import { SidePanel } from './SidePanel'
+import type { MapViewHandle } from '../MapView/MapView'
+import { Sidebar } from '../Sidebar/Sidebar'
+import { MobileHeader } from '../MobileHeader/MobileHeader'
 import { BottomSheet } from './BottomSheet'
-import { ActionBar } from './ActionBar'
+import { MapControls } from '../MapControls/MapControls'
+import { ElevationBar } from '../ElevationBar/ElevationBar'
 import styles from './AppShell.module.css'
 
 export function AppShell() {
   const { isMobile, isTMA } = usePlatform()
   const isDesktop = !isMobile && !isTMA
+  const mapRef = useRef<MapViewHandle>(null)
 
   if (isDesktop) {
     return (
-      <div className={`${styles.shell} ${styles.desktop}`}>
-        <SidePanel />
-        <div className={styles.desktopMap}>
-          <MapView />
+      <div className={styles.desktopGrid}>
+        {/* Map fills the entire grid as background layer */}
+        <div className={styles.mapLayer}>
+          <MapView ref={mapRef} />
+        </div>
+
+        {/* Left column: sidebar */}
+        <div className={styles.sidebarCol}>
+          <Sidebar />
+        </div>
+
+        {/* Center column: empty space (map shows through) */}
+        <div className={styles.centerCol} />
+
+        {/* Right column: map controls */}
+        <div className={styles.controlsCol}>
+          <MapControls mapRef={mapRef} />
+        </div>
+
+        {/* Bottom row: elevation bar */}
+        <div className={styles.elevationRow}>
+          <ElevationBar />
         </div>
       </div>
     )
   }
 
+  // Mobile / TMA layout
   return (
-    <div className={`${styles.shell} ${styles.mobile}`}>
-      <div className={styles.mobileMap}>
-        <MapView />
+    <div className={styles.mobileGrid}>
+      {/* Row 1: top search bar */}
+      <div className={styles.mobileTopRow}>
+        <MobileHeader />
       </div>
-      <BottomSheet />
-      <ActionBar />
+
+      {/* Row 2: spacer (grid gap) */}
+      <div />
+
+      {/* Row 3: full-screen map */}
+      <div className={styles.mobileMapRow}>
+        <MapView ref={mapRef} />
+        <div className={styles.mobileControls}>
+          <MapControls mapRef={mapRef} />
+        </div>
+      </div>
+
+      {/* Row 4: bottom sheet */}
+      <div className={styles.mobileBottomRow}>
+        <BottomSheet />
+      </div>
     </div>
   )
 }

--- a/packages/app/src/components/shell/BottomSheet.module.css
+++ b/packages/app/src/components/shell/BottomSheet.module.css
@@ -2,9 +2,10 @@
   position: absolute;
   left: 0;
   right: 0;
-  /* sit directly above ActionBar */
-  bottom: calc(var(--action-bar-height) + env(safe-area-inset-bottom));
-  background-color: var(--surface);
+  bottom: env(safe-area-inset-bottom, 0);
+  background: var(--surface-variant);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;
   box-shadow: var(--shadow-overlay);
   display: flex;
@@ -15,12 +16,11 @@
 }
 
 .collapsed {
-  /* handle + 80px content peek */
   height: calc(var(--bottom-sheet-handle-height) + var(--bottom-sheet-peek));
 }
 
 .expanded {
-  height: 50vh;
+  height: 60vh;
 }
 
 .handle {
@@ -37,10 +37,29 @@
 }
 
 .handleBar {
-  width: 36px;
+  width: 40px;
   height: 4px;
   border-radius: var(--radius-full);
-  background-color: var(--surface-container-high);
+  background: rgba(68, 86, 181, 0.2);
+  transition: width 0.2s ease, background 0.2s ease;
+}
+
+.handle:hover .handleBar {
+  width: 48px;
+  background: rgba(68, 86, 181, 0.35);
+}
+
+.peek {
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.hint {
+  font-size: 0.8125rem;
+  color: var(--primary);
+  opacity: 0.4;
+  text-align: center;
+  padding: 0.5rem 1rem;
 }
 
 .content {
@@ -48,4 +67,17 @@
   overflow-y: auto;
   overscroll-behavior: contain;
   padding: 0 1rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.profileRow {
+  display: flex;
+  justify-content: center;
+}
+
+.footerAttrib {
+  margin-top: auto;
+  padding-top: 0.5rem;
 }

--- a/packages/app/src/components/shell/BottomSheet.tsx
+++ b/packages/app/src/components/shell/BottomSheet.tsx
@@ -1,9 +1,16 @@
 import { useState } from 'react'
-import { RoutePanel } from '../RoutePanel/RoutePanel'
+import { useMapStore } from '../../store/useMapStore'
+import { ProfileTabs } from '../ProfileTabs/ProfileTabs'
+import { WaypointInputList } from '../WaypointInputList/WaypointInputList'
+import { RouteResults } from '../RouteResults/RouteResults'
+import { ErrorMessage } from '../ErrorMessage/ErrorMessage'
+import { CollapsedFooter } from '../CollapsedFooter/CollapsedFooter'
+import { PoweredBy } from '../PoweredBy/PoweredBy'
 import styles from './BottomSheet.module.css'
 
 export function BottomSheet() {
   const [expanded, setExpanded] = useState(false)
+  const routeResult = useMapStore((s) => s.routeResult)
 
   return (
     <div className={`${styles.sheet} ${expanded ? styles.expanded : styles.collapsed}`}>
@@ -15,9 +22,32 @@ export function BottomSheet() {
       >
         <span className={styles.handleBar} />
       </button>
-      <div className={styles.content}>
-        <RoutePanel />
-      </div>
+
+      {/* Collapsed peek: show route stats or hint */}
+      {!expanded && (
+        <div className={styles.peek} onClick={() => setExpanded(true)}>
+          {routeResult ? (
+            <CollapsedFooter result={routeResult} />
+          ) : (
+            <p className={styles.hint}>Tap to manage waypoints</p>
+          )}
+        </div>
+      )}
+
+      {/* Expanded: full content */}
+      {expanded && (
+        <div className={styles.content}>
+          <div className={styles.profileRow}>
+            <ProfileTabs />
+          </div>
+          <WaypointInputList />
+          <ErrorMessage />
+          {routeResult && <RouteResults result={routeResult} />}
+          <div className={styles.footerAttrib}>
+            <PoweredBy />
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/app/src/components/ui/Button.tsx
+++ b/packages/app/src/components/ui/Button.tsx
@@ -1,3 +1,55 @@
-export function Button() {
-  return null
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'ghost' | 'icon'
+  size?: 'sm' | 'md'
+  children?: ReactNode
+}
+
+export function Button({ variant = 'ghost', size = 'md', children, style, ...rest }: ButtonProps) {
+  const base: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '0.375rem',
+    border: 'none',
+    cursor: 'pointer',
+    fontFamily: 'var(--font-family)',
+    fontWeight: 500,
+    transition: 'opacity 0.15s ease',
+  }
+
+  const variants: Record<string, React.CSSProperties> = {
+    primary: {
+      background: 'linear-gradient(145deg, #151415, #2a2829)',
+      color: 'var(--on-primary)',
+      borderRadius: 'var(--radius-xl)',
+      padding: size === 'sm' ? '0.4rem 0.875rem' : '0.625rem 1.25rem',
+      fontSize: size === 'sm' ? '0.8125rem' : '0.9375rem',
+    },
+    ghost: {
+      background: 'transparent',
+      color: 'var(--primary)',
+      borderRadius: 'var(--radius-md)',
+      padding: size === 'sm' ? '0.375rem 0.625rem' : '0.5rem 0.875rem',
+      fontSize: size === 'sm' ? '0.8125rem' : '0.875rem',
+    },
+    icon: {
+      background: 'var(--surface-variant)',
+      backdropFilter: 'blur(20px)',
+      WebkitBackdropFilter: 'blur(20px)',
+      color: 'var(--primary)',
+      borderRadius: 'var(--radius-full)',
+      width: size === 'sm' ? '36px' : '44px',
+      height: size === 'sm' ? '36px' : '44px',
+      padding: 0,
+      fontSize: '1rem',
+    },
+  }
+
+  return (
+    <button style={{ ...base, ...variants[variant], ...style }} {...rest}>
+      {children}
+    </button>
+  )
 }

--- a/packages/app/src/components/ui/Chip.tsx
+++ b/packages/app/src/components/ui/Chip.tsx
@@ -1,3 +1,35 @@
-export function Chip() {
-  return null
+import type { ReactNode } from 'react'
+
+interface ChipProps {
+  icon?: ReactNode
+  label: string
+  title?: string
+  className?: string
+}
+
+export function Chip({ icon, label, title, className }: ChipProps) {
+  return (
+    <span
+      title={title}
+      className={className}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.3rem',
+        background: 'var(--surface-container-high)',
+        borderRadius: 'var(--radius-full)',
+        padding: '0.3rem 0.7rem',
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        color: 'var(--primary)',
+        fontFamily: 'var(--font-family)',
+        whiteSpace: 'nowrap',
+        boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.55)',
+        letterSpacing: '0.01em',
+      }}
+    >
+      {icon}
+      {label}
+    </span>
+  )
 }

--- a/packages/app/src/components/ui/Input.tsx
+++ b/packages/app/src/components/ui/Input.tsx
@@ -1,3 +1,42 @@
-export function Input() {
-  return null
+import type { InputHTMLAttributes, ReactNode } from 'react'
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  icon?: ReactNode
+}
+
+export function Input({ icon, style, ...rest }: InputProps) {
+  return (
+    <div style={{ position: 'relative', display: 'flex', alignItems: 'center' }}>
+      {icon && (
+        <span
+          style={{
+            position: 'absolute',
+            left: '0.75rem',
+            display: 'flex',
+            alignItems: 'center',
+            pointerEvents: 'none',
+            color: 'var(--primary)',
+            opacity: 0.5,
+          }}
+        >
+          {icon}
+        </span>
+      )}
+      <input
+        style={{
+          width: '100%',
+          background: 'var(--surface-container)',
+          border: 'none',
+          borderRadius: 'var(--radius-md)',
+          padding: icon ? '0.5rem 0.75rem 0.5rem 2.25rem' : '0.5rem 0.75rem',
+          fontFamily: 'var(--font-family)',
+          fontSize: '0.875rem',
+          color: 'var(--primary)',
+          outline: 'none',
+          ...style,
+        }}
+        {...rest}
+      />
+    </div>
+  )
 }

--- a/packages/app/src/hooks/usePhotonSearch.ts
+++ b/packages/app/src/hooks/usePhotonSearch.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from 'react'
+import { searchPhoton, type PhotonFeature } from '../services/photon'
+
+const DEBOUNCE_MS = 300
+
+export function usePhotonSearch(query: string) {
+  const [suggestions, setSuggestions] = useState<PhotonFeature[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (timerRef.current !== null) clearTimeout(timerRef.current)
+    abortRef.current?.abort()
+
+    if (!query.trim()) {
+      setSuggestions([])
+      setIsLoading(false)
+      return
+    }
+
+    setIsLoading(true)
+    timerRef.current = setTimeout(async () => {
+      const controller = new AbortController()
+      abortRef.current = controller
+      const results = await searchPhoton(query, controller.signal)
+      setSuggestions(results)
+      setIsLoading(false)
+    }, DEBOUNCE_MS)
+
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current)
+      abortRef.current?.abort()
+    }
+  }, [query])
+
+  return { suggestions, isLoading }
+}

--- a/packages/app/src/hooks/useProfile.ts
+++ b/packages/app/src/hooks/useProfile.ts
@@ -1,0 +1,7 @@
+import { useMapStore } from '../store/useMapStore'
+
+export function useProfile() {
+  const profile = useMapStore((s) => s.profile)
+  const setProfile = useMapStore((s) => s.actions.setProfile)
+  return { profile, setProfile }
+}

--- a/packages/app/src/hooks/useRoute.ts
+++ b/packages/app/src/hooks/useRoute.ts
@@ -4,7 +4,6 @@ import { useMapStore } from '../store/useMapStore'
 import { buildRoute, RateLimitError } from '../services/graphhopper'
 
 const DEBOUNCE_MS = 500
-const DEFAULT_PROFILE = 'bike' as const
 
 interface UseRouteReturn {
   waypoints: RoutePoint[]
@@ -16,8 +15,9 @@ interface UseRouteReturn {
 
 export function useRoute(): UseRouteReturn {
   const waypoints = useMapStore((s) => s.waypoints)
+  const profile = useMapStore((s) => s.profile)
   const { addWaypoint, removeWaypoint, reorderWaypoints, clearRoute,
-          setRouteResult, setIsRouting } =
+          setRouteResult, setIsRouting, setRouteError } =
     useMapStore((s) => s.actions)
 
   // ── Debounced GraphHopper call ───────────────────────────────────────────
@@ -31,6 +31,7 @@ export function useRoute(): UseRouteReturn {
     if (waypoints.length < 2) {
       setRouteResult(null)
       setIsRouting(false)
+      setRouteError(null)
       return
     }
 
@@ -38,16 +39,19 @@ export function useRoute(): UseRouteReturn {
     timerRef.current = setTimeout(async () => {
       setIsRouting(true)
       try {
-        const result = await buildRoute(waypoints, DEFAULT_PROFILE)
+        const result = await buildRoute(waypoints, profile)
         if (requestIdRef.current !== currentId) return // stale response
         setRouteResult(result)
+        setRouteError(null)
       } catch (err) {
         if (requestIdRef.current !== currentId) return
         setRouteResult(null)
         if (err instanceof RateLimitError) {
-          // Bubble the error for MapView to show as a toast
-          // We store it as a special sentinel in the store via a custom event
-          window.dispatchEvent(new CustomEvent('trailx:ratelimit'))
+          setRouteError('GraphHopper rate limit reached. Add your API key via VITE_GRAPHHOPPER_API_KEY.')
+        } else if (err instanceof Error) {
+          setRouteError(err.message)
+        } else {
+          setRouteError('Routing failed.')
         }
       } finally {
         if (requestIdRef.current === currentId) setIsRouting(false)
@@ -57,7 +61,7 @@ export function useRoute(): UseRouteReturn {
     return () => {
       if (timerRef.current !== null) clearTimeout(timerRef.current)
     }
-  }, [waypoints, setRouteResult, setIsRouting])
+  }, [waypoints, profile, setRouteResult, setIsRouting, setRouteError])
 
   // ── Stable wrapper for addWaypoint ──────────────────────────────────────
   const add = useCallback(

--- a/packages/app/src/services/photon.ts
+++ b/packages/app/src/services/photon.ts
@@ -1,2 +1,46 @@
-export {}
-// TODO: Photon geocoding API (Komoot) — autocomplete, debounce 300ms
+export interface PhotonFeature {
+  geometry: { coordinates: [number, number] }
+  properties: {
+    name: string
+    country?: string
+    city?: string
+    street?: string
+    housenumber?: string
+    state?: string
+  }
+}
+
+interface PhotonResponse {
+  features: PhotonFeature[]
+}
+
+export async function searchPhoton(
+  query: string,
+  signal?: AbortSignal,
+): Promise<PhotonFeature[]> {
+  if (!query.trim()) return []
+
+  const params = new URLSearchParams({ q: query.trim(), lang: 'en', limit: '5' })
+  const url = `https://photon.komoot.io/api/?${params.toString()}`
+
+  try {
+    const response = await fetch(url, { signal })
+    if (!response.ok) return []
+    const data = (await response.json()) as PhotonResponse
+    return data.features ?? []
+  } catch {
+    // Network error, abort, or any other failure — degrade gracefully
+    return []
+  }
+}
+
+export function photonFeatureLabel(feature: PhotonFeature): string {
+  const p = feature.properties
+  const parts: string[] = []
+  if (p.name) parts.push(p.name)
+  if (p.street && p.housenumber) parts.push(`${p.street} ${p.housenumber}`)
+  else if (p.street) parts.push(p.street)
+  if (p.city) parts.push(p.city)
+  if (p.country) parts.push(p.country)
+  return parts.join(', ') || 'Unknown location'
+}

--- a/packages/app/src/store/useMapStore.ts
+++ b/packages/app/src/store/useMapStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { RoutePoint, RouteResult } from '@trailx/shared'
+import type { RoutePoint, RouteResult, RoutingProfile } from '@trailx/shared'
 
 // Re-assigns order and type to every point based on array position.
 function assignTypes(points: RoutePoint[]): RoutePoint[] {
@@ -18,6 +18,8 @@ interface MapStoreActions {
   clearRoute: () => void
   setRouteResult: (result: RouteResult | null) => void
   setIsRouting: (value: boolean) => void
+  setProfile: (profile: RoutingProfile) => void
+  setRouteError: (err: string | null) => void
 }
 
 interface MapStore {
@@ -25,6 +27,8 @@ interface MapStore {
   activeRouteId: string | null
   routeResult: RouteResult | null
   isRouting: boolean
+  profile: RoutingProfile
+  routeError: string | null
   actions: MapStoreActions
 }
 
@@ -33,6 +37,8 @@ export const useMapStore = create<MapStore>((set) => ({
   activeRouteId: null,
   routeResult: null,
   isRouting: false,
+  profile: 'bike',
+  routeError: null,
 
   actions: {
     addWaypoint: (point) =>
@@ -53,10 +59,14 @@ export const useMapStore = create<MapStore>((set) => ({
         return { waypoints: assignTypes(items) }
       }),
 
-    clearRoute: () => set({ waypoints: [], routeResult: null }),
+    clearRoute: () => set({ waypoints: [], routeResult: null, routeError: null }),
 
     setRouteResult: (result) => set({ routeResult: result }),
 
     setIsRouting: (value) => set({ isRouting: value }),
+
+    setProfile: (profile) => set({ profile }),
+
+    setRouteError: (err) => set({ routeError: err }),
   },
 }))

--- a/packages/app/src/styles/globals.css
+++ b/packages/app/src/styles/globals.css
@@ -31,8 +31,10 @@
   /* Layout tokens */
   --action-bar-height: 64px;
   --side-panel-width: 28%;
+  --sidebar-width: 26rem;
   --bottom-sheet-handle-height: 28px;
   --bottom-sheet-peek: 80px;
+  --elevation-bar-height: 48px;
 
   /* Border radius */
   --radius-sm: 0.25rem;


### PR DESCRIPTION
## Summary

- **Full layout rewrite** — AppShell now uses floating sidebar (26rem) | full-screen map | controls column on desktop; MobileHeader + map + collapsible BottomSheet on mobile
- **14 new components** — Sidebar, ProfileTabs, WaypointInput/List, SearchSuggestions, ElevationBar/Chart, MapControls, RouteResults, CollapsedFooter, ErrorMessage, MobileHeader, PoweredBy
- **Design system applied** — DESIGN.md "Tactile Cartographer" palette throughout: glassmorphism overlays, tonal layering (no borders), teardrop map markers, Space Grotesk typography, spring-physics animations

## What changed

**Shell & layout**
- `AppShell` rewritten as CSS Grid; map is `position:absolute` behind all panels
- `BottomSheet` rewritten as collapsible mobile sheet (collapsed chips → expanded route + waypoints)
- `MapView` cleaned up: removed legacy `trailx:ratelimit` DOM event, route line uses brand color

**Store & routing**
- `useMapStore` extended with `profile: RoutingProfile` and `routeError: string | null`
- `useRoute` reads profile from store (profile change re-triggers routing), errors surface via store instead of DOM events
- `photon.ts` implemented (Photon Komoot geocoder, graceful degradation)
- New hooks: `useProfile`, `usePhotonSearch` (300ms debounce + AbortController)

**UI primitives**
- `Chip`, `Button`, `Input` implemented from stubs

## Test plan

- [x] `pnpm dev` — app loads without console errors
- [x] Desktop: sidebar renders as floating card over map, close → hamburger pill, reopen works
- [x] Mobile (≤768px): compact top bar + full-screen map + bottom sheet collapse/expand
- [x] Click map to add waypoints → route draws on map with teardrop markers
- [x] Type in waypoint input → Photon suggestions appear → select geocodes the waypoint
- [x] Profile tab switch (bike/racing/walk) → route re-computes
- [x] Route result: time/distance/elevation chips shown in sidebar card with left accent bar
- [x] ElevationBar: compact → expanded (SVG chart) → closed → reopen
- [x] MapControls zoom +/- and locate button work
- [x] DESIGN.md check: no pixel borders visible, glassmorphism on all overlays, Space Grotesk loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)