### PR TITLE
fix: guard expand()/requestFullscreen() behind initData check in main.tsx

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -13,8 +13,12 @@ import { App } from './App'
 const _twa = window.Telegram?.WebApp
 if (_twa) {
   document.documentElement.style.setProperty('--tma-vh', `${window.innerHeight}px`)
-  _twa.expand()
-  _twa.requestFullscreen?.()
+  // In Telegram's in-app browser initData is '' — calling expand() / requestFullscreen()
+  // there triggers undefined native behavior and corrupts the layout. Only call in real TMA.
+  if (_twa.initData) {
+    _twa.expand()
+    _twa.requestFullscreen?.()
+  }
 }
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
In Telegram's in-app browser (IAB), window.Telegram.WebApp exists but
initData is empty. Calling expand() and requestFullscreen() in this
context triggers undefined native behavior and corrupts the layout.

The useTelegramWebApp hook already had this guard (line 238), but
main.tsx — which runs before React — was missing it.

https://claude.ai/code/session_01BFTRzF7k2Fs2kyBXMys8uD