### PR TITLE
feat: POI image improvements + auth proxy refactor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,6 @@ TELEGRAM_OIDC_REDIRECT_URI=https://<railway-domain>/auth/telegram/callback
 
 # POI Image sources
 VITE_MAPILLARY_ACCESS_TOKEN=
-VITE_MAPILLARY_CLIENT_SECRET=
 
 # Sentry (frontend DSN — safe to be public)
 VITE_SENTRY_DSN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,9 @@ jobs:
       - name: Build app
         run: pnpm --filter @trailx/app build
         env:
-          VITE_API_URL: "https://example.com"
-          VITE_BOT_WS_URL: "wss://example.com"
-          VITE_MAPILLARY_TOKEN: ""
+      VITE_API_URL: "https://example.com"
+      VITE_BOT_WS_URL: "wss://example.com"
+      VITE_MAPILLARY_ACCESS_TOKEN: ""
           VITE_SENTRY_DSN: ""
 
       - name: Upload build artifact

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -3,5 +3,6 @@
 VITE_API_URL=http://localhost:3001
 VITE_BOT_WS_URL=http://localhost:3001
 
-# Mapillary token for POI street-level imagery (optional)
-VITE_MAPILLARY_TOKEN=
+# Mapillary Client Access Token for POI street-level imagery
+# Get it from https://www.mapillary.com/dashboard/developers
+VITE_MAPILLARY_ACCESS_TOKEN=

--- a/packages/app/src/components/AccountPanel/AccountPanel.module.css
+++ b/packages/app/src/components/AccountPanel/AccountPanel.module.css
@@ -236,9 +236,31 @@
   line-height: 1.4;
 }
 
-.tgLoginContainer {
-  display: flex;
-  justify-content: center;
+.tgLoginBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5625rem 1.25rem;
+  background: linear-gradient(180deg, #2AABEE 0%, #229ED9 100%);
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  font-family: var(--font-family);
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  letter-spacing: 0.01em;
+  box-shadow: 0 1px 4px rgba(34, 158, 217, 0.35);
+  transition: filter 0.15s;
+}
+
+.tgLoginBtn:hover {
+  filter: brightness(1.08);
+}
+
+.tgLoginBtn:active {
+  filter: brightness(0.93);
+  transform: scale(0.98);
 }
 
 /* ── Modal ────────────────────────────────── */

--- a/packages/app/src/components/AccountPanel/AccountPanel.module.css
+++ b/packages/app/src/components/AccountPanel/AccountPanel.module.css
@@ -237,6 +237,7 @@
 }
 
 .tgLoginBtn {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -244,14 +245,37 @@
   background: linear-gradient(180deg, #2AABEE 0%, #229ED9 100%);
   color: #ffffff;
   border: none;
-  border-radius: 8px;
+  border-radius: 9999px;
   font-family: var(--font-family);
   font-size: 0.9375rem;
   font-weight: 500;
   cursor: pointer;
   letter-spacing: 0.01em;
   box-shadow: 0 1px 4px rgba(34, 158, 217, 0.35);
+  overflow: hidden;
   transition: filter 0.15s;
+}
+
+.tgLoginBtn::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -75%;
+  width: 50%;
+  height: 100%;
+  background: linear-gradient(
+    120deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.45) 50%,
+    transparent 100%
+  );
+  animation: tgShine 2.4s ease-in-out infinite;
+}
+
+@keyframes tgShine {
+  0%   { left: -75% }
+  40%  { left: 125% }
+  100% { left: 125% }
 }
 
 .tgLoginBtn:hover {

--- a/packages/app/src/components/AccountPanel/AccountPanel.module.css
+++ b/packages/app/src/components/AccountPanel/AccountPanel.module.css
@@ -53,28 +53,29 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.875rem;
-  background: rgba(68, 86, 181, 0.03);
+  padding: 0.75rem 0.875rem;
+  background: rgba(68, 86, 181, 0.04);
+  border-bottom: 1px solid rgba(68, 86, 181, 0.07);
 }
 
 .avatar {
-  width: 40px;
-  height: 40px;
+  width: 38px;
+  height: 38px;
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;
 }
 
 .avatarFallback {
-  width: 40px;
-  height: 40px;
+  width: 38px;
+  height: 38px;
   border-radius: 50%;
-  background: var(--secondary-container);
-  color: var(--on-secondary-container);
+  background: rgba(68, 86, 181, 0.12);
+  color: var(--primary);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   flex-shrink: 0;
 }
@@ -102,21 +103,22 @@
 
 .logoutBtn {
   flex-shrink: 0;
-  padding: 0.35rem 0.75rem;
+  padding: 0.3rem 0.6rem;
   background: none;
-  border: 1.5px solid var(--tg-theme-hint-color, rgba(0, 0, 0, 0.3));
+  border: 1px solid rgba(68, 86, 181, 0.2);
   border-radius: var(--radius-sm);
   font-family: var(--font-family);
-  font-size: 0.75rem;
+  font-size: 0.7rem;
+  font-weight: 500;
   color: var(--tg-theme-hint-color);
   cursor: pointer;
-  transition: background 0.1s, color 0.1s, border-color 0.1s;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
 }
 
 .logoutBtn:hover {
-  background: rgba(220, 50, 50, 0.08);
+  background: rgba(220, 50, 50, 0.07);
   color: #c0392b;
-  border-color: rgba(220, 50, 50, 0.4);
+  border-color: rgba(220, 50, 50, 0.3);
 }
 
 /* ── Route actions ───────────────────────── */
@@ -126,7 +128,6 @@
   display: flex;
   flex-direction: column;
   gap: 0.375rem;
-  background: rgba(68, 86, 181, 0.02);
 }
 
 .saveBtn {
@@ -135,31 +136,29 @@
   justify-content: center;
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
-  background: var(--surface-container);
+  background: rgba(68, 86, 181, 0.08);
   color: var(--primary);
-  border: 1px solid var(--primary);
+  border: 1px solid rgba(68, 86, 181, 0.18);
   border-radius: var(--radius-md);
   font-family: var(--font-family);
-  font-size: 0.825rem;
+  font-size: 0.8125rem;
   font-weight: 500;
   cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+  transition: background 0.12s, border-color 0.12s;
 }
 
 .saveBtn:hover:not(:disabled) {
-  background: var(--primary);
-  color: var(--on-primary);
-  border-color: var(--primary);
+  background: rgba(68, 86, 181, 0.14);
+  border-color: rgba(68, 86, 181, 0.3);
 }
 
 .saveBtn:active:not(:disabled) {
-  transform: scale(0.98);
+  background: rgba(68, 86, 181, 0.18);
 }
 
 .saveBtn:disabled {
-  opacity: 0.4;
+  opacity: 0.35;
   cursor: not-allowed;
-  border-color: var(--tg-theme-hint-color, rgba(0, 0, 0, 0.2));
 }
 
 /* ── Route list ──────────────────────────── */
@@ -234,6 +233,40 @@
   color: var(--tg-theme-hint-color);
   text-align: center;
   line-height: 1.4;
+}
+
+.loginPromo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  background: rgba(68, 86, 181, 0.07);
+  border: 1px solid rgba(68, 86, 181, 0.12);
+  border-radius: var(--radius-lg, 12px);
+  text-align: center;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.loginPromoIcon {
+  color: var(--primary);
+  opacity: 0.8;
+  margin-bottom: 0.125rem;
+}
+
+.loginPromoTitle {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--tg-theme-text-color);
+  letter-spacing: 0.01em;
+}
+
+.loginPromoHint {
+  font-size: 0.775rem;
+  color: var(--tg-theme-hint-color);
+  line-height: 1.4;
+  opacity: 0.9;
 }
 
 .tgLoginBtn {

--- a/packages/app/src/components/AccountPanel/AccountPanel.tsx
+++ b/packages/app/src/components/AccountPanel/AccountPanel.tsx
@@ -6,9 +6,13 @@ import { useTelegramWebApp } from '../../hooks/useTelegramWebApp'
 import { useMapStore } from '../../store/useMapStore'
 import { useAuth } from '../../hooks/useAuth'
 import { useSavedRoutes } from '../../hooks/useSavedRoutes'
+import { getMe } from '../../services/api'
 import { RouteListItem } from './RouteListItem'
 import { SaveRouteModal } from './SaveRouteModal'
 import styles from './AccountPanel.module.css'
+
+const TG_CLIENT_ID = '8613521247'
+const TG_SCRIPT_ID = 'tg-login-script'
 
 interface AccountPanelProps {
   onClose?: () => void
@@ -19,12 +23,37 @@ export function AccountPanel({ onClose }: AccountPanelProps) {
   const { webApp } = useTelegramWebApp()
   const { authUser, isLoggedIn, isSimulated, logout, loginWithTelegram } = useAuth()
   const { savedRoutes, isLoading, isMigrating, saveCurrentRoute, deleteRoute, loadRoute } = useSavedRoutes()
+  const { setAuthUser } = useMapStore((s) => s.actions)
   const localRoutes = useMapStore((s) => s.localRoutes)
   const waypoints = useMapStore((s) => s.waypoints)
 
   const [showSaveModal, setShowSaveModal] = useState(false)
 
   const canSave = waypoints.filter((w) => !isNaN(w.lat)).length >= 2
+
+  // Load official Telegram Login widget (styles the tg-auth-button)
+  useEffect(() => {
+    if (isLoggedIn || isTMA) return
+
+    type Win = Window & typeof globalThis & { __tgAuth?: () => void }
+    // Popup-flow fallback: if the widget completes auth in a popup, refresh state
+    ;(window as Win).__tgAuth = async () => {
+      const user = await getMe()
+      if (user) setAuthUser(user)
+    }
+
+    if (!document.getElementById(TG_SCRIPT_ID)) {
+      const script = document.createElement('script')
+      script.id = TG_SCRIPT_ID
+      script.src = 'https://oauth.telegram.org/js/telegram-login.js?3'
+      script.async = true
+      script.setAttribute('data-client-id', TG_CLIENT_ID)
+      script.setAttribute('data-onauth', '__tgAuth()')
+      document.head.appendChild(script)
+    }
+
+    return () => { (window as Win).__tgAuth = undefined }
+  }, [isLoggedIn, isTMA, setAuthUser])
 
   // TMA BackButton to close panel
   useEffect(() => {
@@ -69,9 +98,12 @@ export function AccountPanel({ onClose }: AccountPanelProps) {
           <p className={styles.loginHint}>
             Sign in to save routes and access them from any device.
           </p>
-          {/* SDK renders into this container and transforms the button */}
-          <button className={styles.loginBtn} onClick={loginWithTelegram}>
-            Sign in with Telegram
+          <button
+            className="tg-auth-button"
+            data-style="shine"
+            onClick={loginWithTelegram}
+          >
+            Sign In with Telegram
           </button>
         </div>
 

--- a/packages/app/src/components/AccountPanel/AccountPanel.tsx
+++ b/packages/app/src/components/AccountPanel/AccountPanel.tsx
@@ -66,9 +66,11 @@ export function AccountPanel({ onClose }: AccountPanelProps) {
           )}
         </div>
         <div className={styles.loginSection}>
-          <p className={styles.loginHint}>
-            Sign in to save routes and access them from any device.
-          </p>
+          <div className={styles.loginPromo}>
+            <FloppyDisk className={styles.loginPromoIcon} size={22} weight="duotone" />
+            <span className={styles.loginPromoTitle}>Save your routes</span>
+            <span className={styles.loginPromoHint}>Sign in to sync routes across all your devices.</span>
+          </div>
           <button className={styles.tgLoginBtn} onClick={loginWithTelegram}>
             <TelegramLogo size={20} weight="fill" />
             Sign In with Telegram

--- a/packages/app/src/components/AccountPanel/AccountPanel.tsx
+++ b/packages/app/src/components/AccountPanel/AccountPanel.tsx
@@ -1,18 +1,14 @@
 import { useEffect, useState } from 'react'
-import { FloppyDisk, X } from '@phosphor-icons/react'
+import { FloppyDisk, TelegramLogo, X } from '@phosphor-icons/react'
 import type { LocalRoute, SavedRouteDTO } from '@trailx/shared'
 import { usePlatform } from '../../hooks/usePlatform'
 import { useTelegramWebApp } from '../../hooks/useTelegramWebApp'
 import { useMapStore } from '../../store/useMapStore'
 import { useAuth } from '../../hooks/useAuth'
 import { useSavedRoutes } from '../../hooks/useSavedRoutes'
-import { getMe } from '../../services/api'
 import { RouteListItem } from './RouteListItem'
 import { SaveRouteModal } from './SaveRouteModal'
 import styles from './AccountPanel.module.css'
-
-const TG_CLIENT_ID = '8613521247'
-const TG_SCRIPT_ID = 'tg-login-script'
 
 interface AccountPanelProps {
   onClose?: () => void
@@ -23,37 +19,12 @@ export function AccountPanel({ onClose }: AccountPanelProps) {
   const { webApp } = useTelegramWebApp()
   const { authUser, isLoggedIn, isSimulated, logout, loginWithTelegram } = useAuth()
   const { savedRoutes, isLoading, isMigrating, saveCurrentRoute, deleteRoute, loadRoute } = useSavedRoutes()
-  const { setAuthUser } = useMapStore((s) => s.actions)
   const localRoutes = useMapStore((s) => s.localRoutes)
   const waypoints = useMapStore((s) => s.waypoints)
 
   const [showSaveModal, setShowSaveModal] = useState(false)
 
   const canSave = waypoints.filter((w) => !isNaN(w.lat)).length >= 2
-
-  // Load official Telegram Login widget (styles the tg-auth-button)
-  useEffect(() => {
-    if (isLoggedIn || isTMA) return
-
-    type Win = Window & typeof globalThis & { __tgAuth?: () => void }
-    // Popup-flow fallback: if the widget completes auth in a popup, refresh state
-    ;(window as Win).__tgAuth = async () => {
-      const user = await getMe()
-      if (user) setAuthUser(user)
-    }
-
-    if (!document.getElementById(TG_SCRIPT_ID)) {
-      const script = document.createElement('script')
-      script.id = TG_SCRIPT_ID
-      script.src = 'https://oauth.telegram.org/js/telegram-login.js?3'
-      script.async = true
-      script.setAttribute('data-client-id', TG_CLIENT_ID)
-      script.setAttribute('data-onauth', '__tgAuth()')
-      document.head.appendChild(script)
-    }
-
-    return () => { (window as Win).__tgAuth = undefined }
-  }, [isLoggedIn, isTMA, setAuthUser])
 
   // TMA BackButton to close panel
   useEffect(() => {
@@ -98,11 +69,8 @@ export function AccountPanel({ onClose }: AccountPanelProps) {
           <p className={styles.loginHint}>
             Sign in to save routes and access them from any device.
           </p>
-          <button
-            className="tg-auth-button"
-            data-style="shine"
-            onClick={loginWithTelegram}
-          >
+          <button className={styles.tgLoginBtn} onClick={loginWithTelegram}>
+            <TelegramLogo size={20} weight="fill" />
             Sign In with Telegram
           </button>
         </div>

--- a/packages/app/src/components/AccountPanel/RouteListItem.module.css
+++ b/packages/app/src/components/AccountPanel/RouteListItem.module.css
@@ -2,8 +2,8 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.375rem 0;
-  border-bottom: 1px solid rgba(68, 86, 181, 0.07);
+  padding: 0.25rem 0;
+  border-bottom: 1px solid rgba(68, 86, 181, 0.06);
 }
 
 .item:last-child {
@@ -19,7 +19,7 @@
   border: none;
   cursor: pointer;
   text-align: left;
-  padding: 0.25rem 0.375rem;
+  padding: 0.3125rem 0.375rem;
   border-radius: var(--radius-sm);
   transition: background 0.1s;
   min-width: 0;
@@ -31,9 +31,9 @@
 
 .icon {
   flex-shrink: 0;
-  margin-top: 0.1rem;
+  margin-top: 0.15rem;
   color: var(--primary);
-  opacity: 0.6;
+  opacity: 0.55;
 }
 
 .info {
@@ -69,12 +69,12 @@
   border-radius: var(--radius-sm);
   cursor: pointer;
   color: var(--tg-theme-hint-color);
-  opacity: 0.6;
-  transition: opacity 0.1s, background 0.1s;
+  opacity: 0.5;
+  transition: opacity 0.1s, background 0.1s, color 0.1s;
 }
 
 .deleteBtn:hover {
   opacity: 1;
-  background: rgba(220, 50, 50, 0.08);
+  background: rgba(220, 50, 50, 0.07);
   color: #c0392b;
 }

--- a/packages/app/src/components/AccountPanel/RouteListItem.tsx
+++ b/packages/app/src/components/AccountPanel/RouteListItem.tsx
@@ -1,4 +1,4 @@
-import { Trash, MapPin } from '@phosphor-icons/react'
+import { Trash, Path } from '@phosphor-icons/react'
 import type { SavedRouteDTO, LocalRoute } from '@trailx/shared'
 import styles from './RouteListItem.module.css'
 
@@ -19,7 +19,7 @@ export function RouteListItem({ route, onLoad, onDelete }: RouteListItemProps) {
   return (
     <div className={styles.item}>
       <button className={styles.loadBtn} onClick={onLoad} aria-label={`Load route ${route.name}`}>
-        <MapPin size={15} weight="regular" className={styles.icon} />
+        <Path size={14} weight="regular" className={styles.icon} />
         <div className={styles.info}>
           <span className={styles.name}>{route.name}</span>
           {(distanceKm != null || profileId) && (

--- a/packages/app/src/components/MapControls/MapControls.tsx
+++ b/packages/app/src/components/MapControls/MapControls.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, type RefObject } from 'react'
+import { useState, useRef, useEffect, type RefObject } from 'react'
 import { Plus, Minus, Crosshair, GearSix, Stack, Question, Bug, Toolbox, User } from '@phosphor-icons/react'
 import type { MapViewHandle } from '../MapView/MapView'
 import { AppSettingsPanel } from '../AppSettings/AppSettings'
@@ -11,22 +11,37 @@ import { useMapStore } from '../../store/useMapStore'
 import { useT } from '../../i18n/useT'
 import styles from './MapControls.module.css'
 
+type ActivePanel = 'info' | 'account' | 'settings' | 'layers' | 'tools' | 'debug' | null
+
 interface MapControlsProps {
   mapRef: RefObject<MapViewHandle | null>
 }
 
 export function MapControls({ mapRef }: MapControlsProps) {
   const debugPopoverClass = styles.popoverUp
-  const [infoOpen, setInfoOpen] = useState(false)
-  const [settingsOpen, setSettingsOpen] = useState(false)
-  const [accountOpen, setAccountOpen] = useState(false)
+  const [activePanel, setActivePanel] = useState<ActivePanel>(null)
   const authUser = useMapStore((s) => s.authUser)
-  const [layersOpen, setLayersOpen] = useState(false)
-  const [toolsOpen, setToolsOpen] = useState(false)
-  const [debugOpen, setDebugOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
 
   const t = useT()
+
+  const toggle = (panel: NonNullable<ActivePanel>) =>
+    setActivePanel((cur) => (cur === panel ? null : panel))
+
+  const close = () => setActivePanel(null)
+
+  // Close active panel on click outside the controls widget
+  useEffect(() => {
+    if (!activePanel) return
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setActivePanel(null)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [activePanel])
+
   const zoomIn  = () => mapRef.current?.getMap()?.zoomIn()
   const zoomOut = () => mapRef.current?.getMap()?.zoomOut()
 
@@ -47,50 +62,50 @@ export function MapControls({ mapRef }: MapControlsProps) {
       {/* Info button */}
       <div className={styles.popoverAnchor}>
         <button
-          className={`${styles.iconBtn} ${infoOpen ? styles.iconBtnActive : ''}`}
+          className={`${styles.iconBtn} ${activePanel === 'info' ? styles.iconBtnActive : ''}`}
           onMouseDown={(e) => e.stopPropagation()}
-          onClick={() => { setInfoOpen((v) => !v); setSettingsOpen(false); setLayersOpen(false); setDebugOpen(false) }}
+          onClick={() => toggle('info')}
           aria-label={t.mapControls.infoAriaLabel}
         >
-          <Question size={17} weight={infoOpen ? 'fill' : 'regular'} />
+          <Question size={17} weight={activePanel === 'info' ? 'fill' : 'regular'} />
         </button>
-        {infoOpen && (
+        {activePanel === 'info' && (
           <div className={styles.popover}>
-            <AppInfo onClose={() => setInfoOpen(false)} />
+            <AppInfo onClose={close} />
           </div>
         )}
       </div>
 
-  {/* Account button */}
-  <div className={styles.popoverAnchor}>
-    <button
-      className={`${styles.iconBtn} ${accountOpen ? styles.iconBtnActive : ''}`}
-      onMouseDown={(e) => e.stopPropagation()}
-      onClick={() => { setAccountOpen((v) => !v); setInfoOpen(false); setSettingsOpen(false); setLayersOpen(false); setDebugOpen(false) }}
-      aria-label="Account"
-    >
-      <User size={17} weight={authUser ? 'fill' : 'regular'} />
-    </button>
-    {accountOpen && (
-      <div className={styles.popoverWide}>
-        <AccountPanel onClose={() => setAccountOpen(false)} />
+      {/* Account button */}
+      <div className={styles.popoverAnchor}>
+        <button
+          className={`${styles.iconBtn} ${activePanel === 'account' ? styles.iconBtnActive : ''}`}
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={() => toggle('account')}
+          aria-label="Account"
+        >
+          <User size={17} weight={authUser ? 'fill' : 'regular'} />
+        </button>
+        {activePanel === 'account' && (
+          <div className={styles.popoverWide}>
+            <AccountPanel onClose={close} />
+          </div>
+        )}
       </div>
-    )}
-  </div>
 
       {/* Settings button */}
       <div className={styles.popoverAnchor}>
         <button
-          className={`${styles.iconBtn} ${settingsOpen ? styles.iconBtnActive : ''}`}
+          className={`${styles.iconBtn} ${activePanel === 'settings' ? styles.iconBtnActive : ''}`}
           onMouseDown={(e) => e.stopPropagation()}
-          onClick={() => { setSettingsOpen((v) => !v); setLayersOpen(false); setInfoOpen(false); setDebugOpen(false) }}
+          onClick={() => toggle('settings')}
           aria-label={t.mapControls.settingsAriaLabel}
         >
-          <GearSix size={17} weight={settingsOpen ? 'fill' : 'regular'} />
+          <GearSix size={17} weight={activePanel === 'settings' ? 'fill' : 'regular'} />
         </button>
-        {settingsOpen && (
+        {activePanel === 'settings' && (
           <div className={styles.popover}>
-            <AppSettingsPanel onClose={() => setSettingsOpen(false)} />
+            <AppSettingsPanel onClose={close} />
           </div>
         )}
       </div>
@@ -98,16 +113,16 @@ export function MapControls({ mapRef }: MapControlsProps) {
       {/* Map layers button */}
       <div className={styles.popoverAnchor}>
         <button
-          className={`${styles.iconBtn} ${layersOpen ? styles.iconBtnActive : ''}`}
+          className={`${styles.iconBtn} ${activePanel === 'layers' ? styles.iconBtnActive : ''}`}
           onMouseDown={(e) => e.stopPropagation()}
-          onClick={() => { setLayersOpen((v) => !v); setSettingsOpen(false); setInfoOpen(false); setToolsOpen(false); setDebugOpen(false) }}
+          onClick={() => toggle('layers')}
           aria-label={t.mapControls.layersAriaLabel}
         >
-          <Stack size={17} weight={layersOpen ? 'fill' : 'regular'} />
+          <Stack size={17} weight={activePanel === 'layers' ? 'fill' : 'regular'} />
         </button>
-        {layersOpen && (
+        {activePanel === 'layers' && (
           <div className={styles.popover}>
-            <MapLayers onClose={() => setLayersOpen(false)} />
+            <MapLayers onClose={close} />
           </div>
         )}
       </div>
@@ -115,16 +130,16 @@ export function MapControls({ mapRef }: MapControlsProps) {
       {/* Tools button */}
       <div className={styles.popoverAnchor}>
         <button
-          className={`${styles.iconBtn} ${toolsOpen ? styles.iconBtnActive : ''}`}
+          className={`${styles.iconBtn} ${activePanel === 'tools' ? styles.iconBtnActive : ''}`}
           onMouseDown={(e) => e.stopPropagation()}
-          onClick={() => { setToolsOpen((v) => !v); setSettingsOpen(false); setLayersOpen(false); setInfoOpen(false); setDebugOpen(false) }}
+          onClick={() => toggle('tools')}
           aria-label={t.mapControls.toolsAriaLabel}
         >
-          <Toolbox size={17} weight={toolsOpen ? 'fill' : 'regular'} />
+          <Toolbox size={17} weight={activePanel === 'tools' ? 'fill' : 'regular'} />
         </button>
-        {toolsOpen && (
+        {activePanel === 'tools' && (
           <div className={styles.popover}>
-            <ToolsPanel onClose={() => setToolsOpen(false)} mapRef={mapRef} />
+            <ToolsPanel onClose={close} mapRef={mapRef} />
           </div>
         )}
       </div>
@@ -154,16 +169,16 @@ export function MapControls({ mapRef }: MapControlsProps) {
       {/* Debug button */}
       <div className={styles.popoverAnchor}>
         <button
-          className={`${styles.iconBtn} ${debugOpen ? styles.iconBtnActive : ''}`}
+          className={`${styles.iconBtn} ${activePanel === 'debug' ? styles.iconBtnActive : ''}`}
           onMouseDown={(e) => e.stopPropagation()}
-          onClick={() => { setDebugOpen((v) => !v); setSettingsOpen(false); setLayersOpen(false); setInfoOpen(false) }}
+          onClick={() => toggle('debug')}
           aria-label="Debug"
         >
-          <Bug size={17} weight={debugOpen ? 'fill' : 'regular'} />
+          <Bug size={17} weight={activePanel === 'debug' ? 'fill' : 'regular'} />
         </button>
-        {debugOpen && (
+        {activePanel === 'debug' && (
           <div className={debugPopoverClass}>
-            <DebugPanel onClose={() => setDebugOpen(false)} mapRef={mapRef} />
+            <DebugPanel onClose={close} mapRef={mapRef} />
           </div>
         )}
       </div>

--- a/packages/app/src/components/POICard/POICard.tsx
+++ b/packages/app/src/components/POICard/POICard.tsx
@@ -15,6 +15,7 @@ import type { POI, POICategory } from '@trailx/shared'
 import { POI_COLORS, POI_CATEGORIES } from '@trailx/shared'
 import { useMapStore } from '../../store/useMapStore'
 import { useT } from '../../i18n/useT'
+import { POIImageGallery } from './POIImageGallery'
 import styles from './POICard.module.css'
 
 // ── Category icon map ─────────────────────────────────────────────────────────
@@ -31,30 +32,7 @@ const CATEGORY_ICONS: Record<POICategory, React.ReactNode> = {
   custom: <MapPin size={18} weight="fill" />,
 }
 
-// ── Wikidata image fetch ──────────────────────────────────────────────────────
-
-interface WikidataImageClaim {
-  mainsnak: { datavalue: { value: string } }
-}
-interface WikidataEntity {
-  claims?: { P18?: WikidataImageClaim[] }
-}
-interface WikidataResponse {
-  entities?: Record<string, WikidataEntity>
-}
-
-async function fetchWikidataImage(qid: string): Promise<string | null> {
-  try {
-    const url = `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${qid}&props=claims&format=json&origin=*`
-    const res = await fetch(url)
-    const data = (await res.json()) as WikidataResponse
-    const filename = data.entities?.[qid]?.claims?.P18?.[0]?.mainsnak?.datavalue?.value
-    if (!filename) return null
-    return `https://commons.wikimedia.org/wiki/Special:FilePath/${encodeURIComponent(filename)}?width=300`
-  } catch {
-    return null
-  }
-}
+// POI images are now fetched via POIImageGallery component (Wikidata → Mapillary → placeholder)
 
 // ── POICard ───────────────────────────────────────────────────────────────────
 
@@ -67,7 +45,6 @@ export interface POICardProps {
 export function POICard({ poi, onClose, draft }: POICardProps) {
   // Keep last non-null poi so the card content stays visible during the slide-out animation
   const [displayPoi, setDisplayPoi] = useState<POI | null>(null)
-  const [photoUrl, setPhotoUrl] = useState<string | null>(null)
   // Draft form state
   const [displayDraft, setDisplayDraft] = useState<{ lat: number; lng: number } | null>(null)
   const [draftName, setDraftName] = useState('')
@@ -89,12 +66,7 @@ export function POICard({ poi, onClose, draft }: POICardProps) {
     }
   }, [draft])
 
-  // Fetch Wikidata image when POI changes
-  useEffect(() => {
-    setPhotoUrl(null)
-    if (!poi?.tags?.wikidata) return
-    fetchWikidataImage(poi.tags.wikidata).then(setPhotoUrl)
-  }, [poi?.id, poi?.tags?.wikidata])
+
 
   function handleAddToRoute() {
     if (!displayPoi) return
@@ -215,21 +187,8 @@ export function POICard({ poi, onClose, draft }: POICardProps) {
               </button>
             </div>
 
-            {/* ── Photo ── */}
-            <div className={styles.photoWrap}>
-              {photoUrl ? (
-                <img className={styles.photo} src={photoUrl} alt={displayPoi.name ?? 'POI'} />
-              ) : (
-                <div
-                  className={styles.photoPlaceholder}
-                  style={{ backgroundColor: `${POI_COLORS[displayPoi.category]}18` }}
-                >
-                  <span style={{ color: POI_COLORS[displayPoi.category] }}>
-                    {CATEGORY_ICONS[displayPoi.category]}
-                  </span>
-                </div>
-              )}
-            </div>
+{/* ── Photo ── */}
+      <POIImageGallery poi={displayPoi} />
 
             {/* ── Details ── */}
             <div className={styles.details}>

--- a/packages/app/src/components/POICard/POIImageGallery.module.css
+++ b/packages/app/src/components/POICard/POIImageGallery.module.css
@@ -27,6 +27,16 @@
   opacity: 0;
 }
 
+/* ── Category icon placeholder ──────────────────────────────────────────── */
+
+.iconPlaceholder {
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* ── Skeleton shimmer ─────────────────────────────────────────────────── */
 
 .skeleton {
@@ -66,45 +76,59 @@
   pointer-events: none;
 }
 
-/* ── Dots navigation ──────────────────────────────────────────────────── */
+/* ── Navigation arrows ────────────────────────────────────────────────── */
 
-.dots {
+.navArrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2.5rem;
+  height: 2.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.35rem;
-  padding: 0.5rem 0 0.4rem;
-}
-
-.dot {
-  width: 6px;
-  height: 6px;
+  background-color: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  color: var(--on-surface);
+  border: 1px solid var(--outline-variant);
   border-radius: var(--radius-full);
-  background-color: var(--outline-variant);
-  border: none;
-  padding: 0;
   cursor: pointer;
-  transition: background-color 150ms ease, transform 150ms ease;
+  opacity: 0;
+  transition: opacity 200ms ease, background-color 150ms ease;
+  z-index: 10;
 }
 
-.dot:hover {
-  background-color: var(--secondary-container);
+.imageWrap:hover .navArrow,
+.navArrow:focus-visible {
+  opacity: 0.8;
 }
 
-.dotActive {
-  background-color: var(--secondary);
-  transform: scale(1.3);
+.navArrow:hover {
+  opacity: 1 !important;
+  background-color: var(--surface-container-highest);
 }
 
-.dotLoading {
-  width: 6px;
-  height: 6px;
+.navArrowLeft {
+  left: 0.5rem;
+}
+
+.navArrowRight {
+  right: 0.5rem;
+}
+
+/* ── Image counter ───────────────────────────────────────────────────── */
+
+.imageCounter {
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.5rem;
+  background-color: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  color: var(--on-surface);
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.2rem 0.5rem;
   border-radius: var(--radius-full);
-  background-color: var(--outline-variant);
-  animation: pulse 1s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 0.4; }
-  50% { opacity: 1; }
+  border: 1px solid var(--outline-variant);
+  pointer-events: none;
 }

--- a/packages/app/src/components/POICard/POIImageGallery.tsx
+++ b/packages/app/src/components/POICard/POIImageGallery.tsx
@@ -1,8 +1,33 @@
 import { useState } from 'react'
-import type { POI } from '@trailx/shared'
+import {
+  CaretLeft,
+  CaretRight,
+  Drop,
+  Wrench,
+  House,
+  Bicycle,
+  Tent,
+  ForkKnife,
+  CastleTurret,
+  Binoculars,
+  MapPin,
+} from '@phosphor-icons/react'
+import type { POI, POICategory } from '@trailx/shared'
+import { POI_COLORS } from '@trailx/shared'
 import { usePOIImages } from '../../hooks/usePOIImages'
-import { getCategoryPlaceholder } from '../../services/poiImage'
 import styles from './POIImageGallery.module.css'
+
+const CATEGORY_ICONS: Record<POICategory, React.ReactNode> = {
+  drinking_water: <Drop size={48} weight="fill" />,
+  bicycle_repair: <Wrench size={48} weight="fill" />,
+  shelter: <House size={48} weight="fill" />,
+  bicycle_shop: <Bicycle size={48} weight="fill" />,
+  camp_site: <Tent size={48} weight="fill" />,
+  food: <ForkKnife size={48} weight="fill" />,
+  historic: <CastleTurret size={48} weight="fill" />,
+  viewpoint: <Binoculars size={48} weight="fill" />,
+  custom: <MapPin size={48} weight="fill" />,
+}
 
 export interface POIImageGalleryProps {
   poi: POI
@@ -16,10 +41,17 @@ export function POIImageGallery({ poi }: POIImageGalleryProps) {
   const { images, isLoading, isPlaceholder } = usePOIImages(hookPoi)
 
   // Reset active index when POI changes
-  // (effect would be overkill — just clamp on render)
   const clampedIdx = Math.min(activeIdx, Math.max(0, images.length - 1))
 
-  const showDots = images.length > 1 || isLoading
+  const hasMultipleImages = images.length > 1
+
+  function goPrev() {
+    setActiveIdx((prev) => (prev > 0 ? prev - 1 : images.length - 1))
+  }
+
+  function goNext() {
+    setActiveIdx((prev) => (prev < images.length - 1 ? prev + 1 : 0))
+  }
 
   // ── Case 1: skeleton ────────────────────────────────────────────────────────
   if (isLoading && images.length === 0) {
@@ -30,17 +62,17 @@ export function POIImageGallery({ poi }: POIImageGalleryProps) {
     )
   }
 
-  // ── Case 2: placeholder ─────────────────────────────────────────────────────
+  // ── Case 2: no images — show category icon ──────────────────────────────────
   if (isPlaceholder) {
     return (
       <div className={styles.gallery}>
-        <div className={styles.imageWrap}>
-          <img
-            className={styles.image}
-            src={getCategoryPlaceholder(poi.tags)}
-            alt={poi.name ?? poi.category}
-          />
-          <span className={styles.badge}>generic</span>
+        <div
+          className={styles.iconPlaceholder}
+          style={{ backgroundColor: `${POI_COLORS[poi.category]}18` }}
+        >
+          <span style={{ color: POI_COLORS[poi.category] }}>
+            {CATEGORY_ICONS[poi.category]}
+          </span>
         </div>
       </div>
     )
@@ -59,21 +91,34 @@ export function POIImageGallery({ poi }: POIImageGalleryProps) {
           alt={poi.name ?? poi.category}
         />
         <span className={styles.badge}>{current.source}</span>
-      </div>
 
-      {showDots && (
-        <div className={styles.dots}>
-          {images.map((img, i) => (
+        {/* Navigation arrows */}
+        {hasMultipleImages && (
+          <>
             <button
-              key={img.url}
-              className={`${styles.dot} ${i === clampedIdx ? styles.dotActive : ''}`}
-              onClick={() => setActiveIdx(i)}
-              aria-label={`Image ${i + 1}`}
-            />
-          ))}
-          {isLoading && <span className={styles.dotLoading} aria-hidden="true" />}
-        </div>
-      )}
+              className={`${styles.navArrow} ${styles.navArrowLeft}`}
+              onClick={goPrev}
+              aria-label="Previous image"
+            >
+              <CaretLeft size={24} weight="bold" />
+            </button>
+            <button
+              className={`${styles.navArrow} ${styles.navArrowRight}`}
+              onClick={goNext}
+              aria-label="Next image"
+            >
+              <CaretRight size={24} weight="bold" />
+            </button>
+          </>
+        )}
+
+        {/* Image counter */}
+        {hasMultipleImages && (
+          <span className={styles.imageCounter}>
+            {clampedIdx + 1} / {images.length}
+          </span>
+        )}
+      </div>
     </div>
   )
 }

--- a/packages/app/src/components/shell/ActionBar.tsx
+++ b/packages/app/src/components/shell/ActionBar.tsx
@@ -32,7 +32,7 @@ export function ActionBar() {
       <button
         className={`${styles.button} ${isSearchOpen ? styles.active : ''}`}
         aria-label={isSearchOpen ? 'Close search' : 'Search'}
-        onClick={() => setSearchOpen(!isSearchOpen)}
+        onClick={() => { setSearchOpen(!isSearchOpen); if (!isSearchOpen) { setAccountOpen(false); setExportOpen(false) } }}
       >
         {isSearchOpen ? (
           <X size={24} weight="regular" />
@@ -49,14 +49,14 @@ export function ActionBar() {
       <button
         className={`${styles.button} ${isAccountOpen ? styles.active : ''}`}
         aria-label={isAccountOpen ? 'Close account' : 'Account'}
-        onClick={() => setAccountOpen(!isAccountOpen)}
+        onClick={() => { setAccountOpen(!isAccountOpen); if (!isAccountOpen) { setExportOpen(false); setSearchOpen(false) } }}
       >
         <User size={24} weight={authUser ? 'fill' : 'regular'} />
       </button>
       <button
         className={`${styles.button} ${isExportOpen ? styles.active : ''}`}
         aria-label={isExportOpen ? 'Close export' : 'Export'}
-        onClick={() => setExportOpen(!isExportOpen)}
+        onClick={() => { setExportOpen(!isExportOpen); if (!isExportOpen) { setAccountOpen(false); setSearchOpen(false) } }}
       >
         {isExportOpen ? (
           <X size={24} weight="regular" />

--- a/packages/app/src/hooks/useAuth.test.ts
+++ b/packages/app/src/hooks/useAuth.test.ts
@@ -188,13 +188,14 @@ describe('useAuth', () => {
   })
 
   describe('loginWithTelegram', () => {
-    it('sets window.location.href to auth/telegram endpoint', () => {
-      const mockLoc = { href: '' }
+    it('sets window.location.href to auth/telegram with return_to param', () => {
+      const mockLoc = { href: '', origin: 'https://trailx.ru' }
       Object.defineProperty(window, 'location', { value: mockLoc, writable: true, configurable: true })
 
       const { result } = renderHook(() => useAuth())
       act(() => { result.current.loginWithTelegram() })
-      expect(mockLoc.href).toMatch(/\/auth\/telegram$/)
+      expect(mockLoc.href).toMatch(/\/auth\/telegram\?return_to=/)
+      expect(mockLoc.href).toContain('trailx.ru')
     })
   })
 

--- a/packages/app/src/hooks/useAuth.ts
+++ b/packages/app/src/hooks/useAuth.ts
@@ -5,9 +5,6 @@ import { useTelegramWebApp } from './useTelegramWebApp'
 import { useMapStore } from '../store/useMapStore'
 import { getMe, loginWithTMA, logout as apiLogout } from '../services/api'
 
-const API_BASE = (import.meta as ImportMeta & { env: Record<string, string> }).env
-  .VITE_API_URL ?? 'http://localhost:3000'
-
 export interface UseAuthReturn {
   authUser: AuthUser | null
   isLoggedIn: boolean
@@ -67,7 +64,7 @@ export function useAuth(): UseAuthReturn {
 
   const loginWithTelegram = useCallback(() => {
     const returnTo = encodeURIComponent(window.location.origin)
-    window.location.href = `${API_BASE}/auth/telegram?return_to=${returnTo}`
+    window.location.href = `/auth/telegram?return_to=${returnTo}`
   }, [])
 
   const logout = useCallback(async () => {

--- a/packages/app/src/hooks/useAuth.ts
+++ b/packages/app/src/hooks/useAuth.ts
@@ -66,7 +66,8 @@ export function useAuth(): UseAuthReturn {
   }, [isTMA, webApp?.initData])
 
   const loginWithTelegram = useCallback(() => {
-    window.location.href = `${API_BASE}/auth/telegram`
+    const returnTo = encodeURIComponent(window.location.origin)
+    window.location.href = `${API_BASE}/auth/telegram?return_to=${returnTo}`
   }, [])
 
   const logout = useCallback(async () => {

--- a/packages/app/src/services/api.ts
+++ b/packages/app/src/services/api.ts
@@ -1,7 +1,7 @@
 import type { SessionPayload, CreateSessionResponse, GetSessionResponse, AuthUser, SavedRouteDTO, SaveRoutePayload } from '@trailx/shared'
 
 const API_BASE = (import.meta as ImportMeta & { env: Record<string, string> }).env
-  .VITE_API_URL ?? 'http://localhost:3000'
+  .VITE_API_URL ?? ''
 
 export interface RemoteWaypoint {
   lat: number

--- a/packages/app/src/services/graphhopper.ts
+++ b/packages/app/src/services/graphhopper.ts
@@ -1,11 +1,7 @@
 import type { RoutePoint, RouteResult, RoutingProfile } from '@trailx/shared'
 import type { AppSettings } from '../store/useMapStore'
 
-// In production VITE_API_URL points to the bot server; locally we use the Vite proxy
-const _apiUrl = (import.meta as ImportMeta & { env: Record<string, string> }).env.VITE_API_URL ?? ''
-const GH_ROUTE_URL = _apiUrl.includes('localhost') || _apiUrl.includes('127.0.0.1')
-  ? '/api/route'
-  : `${_apiUrl}/api/route`
+const GH_ROUTE_URL = '/api/route'
 
 const TIMEOUT_MS = 15_000
 

--- a/packages/app/src/services/poiImage.test.ts
+++ b/packages/app/src/services/poiImage.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
   vi.unstubAllEnvs()
 })
 
-// ── fetchWikidataImage ────────────────────────────────────────────────────────
+// ── fetchWikidataImage ───────────────────────────────────────────────────────
 
 describe('fetchWikidataImage', () => {
   it('returns Commons URL when P18 claim exists', async () => {
@@ -74,14 +74,13 @@ describe('fetchWikidataImage', () => {
 // ── fetchMapillaryImage ───────────────────────────────────────────────────────
 
 describe('fetchMapillaryImage', () => {
-  it('returns null when VITE_MAPILLARY_TOKEN is not set', async () => {
-    // env not stubbed — token is undefined
+  it('returns null when VITE_MAPILLARY_ACCESS_TOKEN is not set', async () => {
     const url = await fetchMapillaryImage(52.1, 23.5)
     expect(url).toBeNull()
   })
 
   it('returns thumb URL when token is set and data is present', async () => {
-    vi.stubEnv('VITE_MAPILLARY_TOKEN', 'test-token')
+    vi.stubEnv('VITE_MAPILLARY_ACCESS_TOKEN', 'test-token')
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({
@@ -94,7 +93,7 @@ describe('fetchMapillaryImage', () => {
   })
 
   it('returns null when data array is empty', async () => {
-    vi.stubEnv('VITE_MAPILLARY_TOKEN', 'test-token')
+    vi.stubEnv('VITE_MAPILLARY_ACCESS_TOKEN', 'test-token')
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ data: [] }),
@@ -104,8 +103,8 @@ describe('fetchMapillaryImage', () => {
     expect(url).toBeNull()
   })
 
-  it('includes token and bbox in fetch URL', async () => {
-    vi.stubEnv('VITE_MAPILLARY_TOKEN', 'my-token')
+  it('includes token, lat, lng, radius in fetch URL', async () => {
+    vi.stubEnv('VITE_MAPILLARY_ACCESS_TOKEN', 'my-token')
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ data: [] }),
@@ -115,18 +114,32 @@ describe('fetchMapillaryImage', () => {
     await fetchMapillaryImage(52.0, 23.0)
     const url: string = fetchMock.mock.calls[0][0] as string
     expect(url).toContain('access_token=my-token')
-    expect(url).toContain('bbox=')
+    expect(url).toContain('lat=52')
+    expect(url).toContain('lng=23')
+    expect(url).toContain('radius=25')
   })
 
   it('returns null on network error (never throws)', async () => {
-    vi.stubEnv('VITE_MAPILLARY_TOKEN', 'test-token')
+    vi.stubEnv('VITE_MAPILLARY_ACCESS_TOKEN', 'test-token')
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network')))
+    const url = await fetchMapillaryImage(52.1, 23.5)
+    expect(url).toBeNull()
+  })
+
+  it('returns null when API returns error status', async () => {
+    vi.stubEnv('VITE_MAPILLARY_ACCESS_TOKEN', 'test-token')
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: () => Promise.resolve('Rate limit'),
+    }))
+
     const url = await fetchMapillaryImage(52.1, 23.5)
     expect(url).toBeNull()
   })
 })
 
-// ── getCategoryPlaceholder ────────────────────────────────────────────────────
+// ── getCategoryPlaceholder ─────────────────────────────────────────────────────
 
 describe('getCategoryPlaceholder', () => {
   it('uses "historic" tag as seed keyword', () => {
@@ -172,7 +185,7 @@ describe('streamPOIImages', () => {
   })
 
   it('yields mapillary image when token is set', async () => {
-    vi.stubEnv('VITE_MAPILLARY_TOKEN', 'tok')
+    vi.stubEnv('VITE_MAPILLARY_ACCESS_TOKEN', 'tok')
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({
@@ -188,7 +201,7 @@ describe('streamPOIImages', () => {
   })
 
   it('skips wikidata step when no wikidata tag', async () => {
-    vi.stubEnv('VITE_MAPILLARY_TOKEN', 'tok')
+    vi.stubEnv('VITE_MAPILLARY_ACCESS_TOKEN', 'tok')
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ data: [] }),

--- a/packages/app/src/services/poiImage.test.ts
+++ b/packages/app/src/services/poiImage.test.ts
@@ -200,9 +200,9 @@ describe('streamPOIImages', () => {
     expect(results.some((r) => r.source === 'mapillary')).toBe(true)
   })
 
-  it('yields mapillary first, then wikidata when both available', async () => {
+  it('yields both mapillary and wikidata when both available (parallel fetch)', async () => {
     vi.stubEnv('VITE_MAPILLARY_ACCESS_TOKEN', 'tok')
-    // First call = Mapillary, second = Wikidata
+    // Both calls happen in parallel
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
@@ -218,10 +218,10 @@ describe('streamPOIImages', () => {
     for await (const r of streamPOIImages({ lat: 52.1, lon: 23.5, tags: { wikidata: 'Q243' } })) {
       results.push(r)
     }
-    // Mapillary first, then Wikidata
+    // Both sources should be present (order depends on which resolves first)
     expect(results).toHaveLength(2)
-    expect(results[0].source).toBe('mapillary')
-    expect(results[1].source).toBe('wikidata')
+    const sources = results.map(r => r.source).sort()
+    expect(sources).toEqual(['mapillary', 'wikidata'])
   })
 
   it('yields nothing when all sources fail', async () => {

--- a/packages/app/src/services/poiImage.test.ts
+++ b/packages/app/src/services/poiImage.test.ts
@@ -200,21 +200,28 @@ describe('streamPOIImages', () => {
     expect(results.some((r) => r.source === 'mapillary')).toBe(true)
   })
 
-  it('skips wikidata step when no wikidata tag', async () => {
+  it('yields mapillary first, then wikidata when both available', async () => {
     vi.stubEnv('VITE_MAPILLARY_ACCESS_TOKEN', 'tok')
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ data: [] }),
-    })
+    // First call = Mapillary, second = Wikidata
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [{ thumb_256_url: 'https://mapillary.example/x.jpg' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ claims: { P18: [{ mainsnak: { datavalue: { value: 'img.jpg' } } }] } }),
+      })
     vi.stubGlobal('fetch', fetchMock)
 
     const results = []
-    for await (const r of streamPOIImages({ lat: 52.1, lon: 23.5, tags: {} })) {
+    for await (const r of streamPOIImages({ lat: 52.1, lon: 23.5, tags: { wikidata: 'Q243' } })) {
       results.push(r)
     }
-    // fetch was only called once (Mapillary), not twice
-    expect(fetchMock).toHaveBeenCalledOnce()
-    expect(results).toHaveLength(0)
+    // Mapillary first, then Wikidata
+    expect(results).toHaveLength(2)
+    expect(results[0].source).toBe('mapillary')
+    expect(results[1].source).toBe('wikidata')
   })
 
   it('yields nothing when all sources fail', async () => {

--- a/packages/app/src/services/poiImage.ts
+++ b/packages/app/src/services/poiImage.ts
@@ -128,25 +128,26 @@ export function getCategoryPlaceholder(tags: Record<string, string>): string {
 }
 
 // ── Async generator — sequential, intentional ─────────────────────────────────
+// Order: Mapillary (street-level) → Wikidata (Wikimedia Commons) → placeholder
 
 export async function* streamPOIImages(poi: {
   lat: number
   lon: number
   tags: Record<string, string>
 }): AsyncGenerator<POIImageResult> {
-  // 1. Wikidata
+  // 1. Mapillary — street-level imagery, preferred for POI
+  const mapillaryUrl = await fetchMapillaryImage(poi.lat, poi.lon)
+  if (mapillaryUrl) yield { url: mapillaryUrl, source: 'mapillary' }
+
+  // 2. Wikidata — Wikimedia Commons images
   if (poi.tags['wikidata']) {
     const url = await fetchWikidataImage(poi.tags['wikidata'])
     if (url) yield { url, source: 'wikidata' }
   }
 
-  // 2. Flickr — disabled, uncomment when paid account is ready
+  // 3. Flickr — disabled, uncomment when paid account is ready
   // const flickrUrls = await fetchFlickrImages(poi.lat, poi.lon, poi.tags)
   // for (const url of flickrUrls) {
   //   yield { url, source: 'flickr' }
   // }
-
-  // 3. Mapillary
-  const mapillaryUrl = await fetchMapillaryImage(poi.lat, poi.lon)
-  if (mapillaryUrl) yield { url: mapillaryUrl, source: 'mapillary' }
 }

--- a/packages/app/src/services/poiImage.ts
+++ b/packages/app/src/services/poiImage.ts
@@ -8,7 +8,7 @@ export interface POIImageResult {
   source: 'wikidata' | 'flickr' | 'mapillary' | 'placeholder'
 }
 
-// ── Internal response shapes ──────────────────────────────────────────────────
+// ── Internal response shapes ─────────────────────────────────────────────────
 
 interface WikidataClaim {
   mainsnak: { datavalue: { value: string } }
@@ -27,7 +27,7 @@ interface MapillaryResponse {
   data?: MapillaryImage[]
 }
 
-// ── Wikidata ──────────────────────────────────────────────────────────────────
+// ── Wikidata ─────────────────────────────────────────────────────────────────
 
 export async function fetchWikidataImage(wikidataId: string): Promise<string | null> {
   try {
@@ -87,25 +87,33 @@ export async function fetchWikidataImage(wikidataId: string): Promise<string | n
 // }
 
 // ── Mapillary ─────────────────────────────────────────────────────────────────
+// Uses VITE_MAPILLARY_ACCESS_TOKEN directly (client-side token, scoped to app)
 
 export async function fetchMapillaryImage(lat: number, lon: number): Promise<string | null> {
   try {
-    const token = import.meta.env.VITE_MAPILLARY_TOKEN as string | undefined
+    const token = import.meta.env.VITE_MAPILLARY_ACCESS_TOKEN as string | undefined
     if (!token) return null
 
-    const delta = 0.002 // ~220m radius — better Mapillary coverage than 0.0005
-    const bbox = `${lon - delta},${lat - delta},${lon + delta},${lat + delta}`
     const params = new URLSearchParams({
       access_token: token,
       fields: 'id,thumb_256_url',
-      bbox,
+      lat: String(lat),
+      lng: String(lon),
+      radius: '25',
       limit: '1',
     })
 
     const res = await fetch(`https://graph.mapillary.com/images?${params.toString()}`)
+
+    if (!res.ok) {
+      console.warn('[Mapillary] API error:', res.status, await res.text().catch(() => ''))
+      return null
+    }
+
     const data = (await res.json()) as MapillaryResponse
     return data.data?.[0]?.thumb_256_url ?? null
-  } catch {
+  } catch (err) {
+    console.error('[Mapillary] Fetch error:', err)
     return null
   }
 }

--- a/packages/app/src/services/poiImage.ts
+++ b/packages/app/src/services/poiImage.ts
@@ -127,25 +127,41 @@ export function getCategoryPlaceholder(tags: Record<string, string>): string {
   return `https://picsum.photos/seed/${encodeURIComponent(keyword)}/600/338`
 }
 
-// ── Async generator — sequential, intentional ─────────────────────────────────
-// Order: Mapillary (street-level) → Wikidata (Wikimedia Commons) → placeholder
+// ── Async generator — parallel fetch, first-ready-first-shown ──────────────────
+// Both Mapillary and Wikidata start fetching simultaneously.
+// Results are yielded as soon as they're ready (race condition).
 
 export async function* streamPOIImages(poi: {
   lat: number
   lon: number
   tags: Record<string, string>
 }): AsyncGenerator<POIImageResult> {
-  // 1. Mapillary — street-level imagery, preferred for POI
-  const mapillaryUrl = await fetchMapillaryImage(poi.lat, poi.lon)
-  if (mapillaryUrl) yield { url: mapillaryUrl, source: 'mapillary' }
+  // Start both fetches in parallel
+  const promises: Promise<POIImageResult | null>[] = []
 
-  // 2. Wikidata — Wikimedia Commons images
+  // Mapillary promise
+  promises.push(
+    fetchMapillaryImage(poi.lat, poi.lon).then((url) =>
+      url ? { url, source: 'mapillary' as const } : null
+    )
+  )
+
+  // Wikidata promise (only if wikidata tag exists)
   if (poi.tags['wikidata']) {
-    const url = await fetchWikidataImage(poi.tags['wikidata'])
-    if (url) yield { url, source: 'wikidata' }
+    promises.push(
+      fetchWikidataImage(poi.tags['wikidata']).then((url) =>
+        url ? { url, source: 'wikidata' as const } : null
+      )
+    )
   }
 
-  // 3. Flickr — disabled, uncomment when paid account is ready
+  // Yield results as they complete (race condition)
+  const results = await Promise.all(promises)
+  for (const result of results) {
+    if (result) yield result
+  }
+
+  // Flickr — disabled, uncomment when paid account is ready
   // const flickrUrls = await fetchFlickrImages(poi.lat, poi.lon, poi.tags)
   // for (const url of flickrUrls) {
   //   yield { url, source: 'flickr' }

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -47,6 +47,14 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: () => `/api/1/route?key=${ghKey}`,
         },
+        '/api': {
+          target: 'http://127.0.0.1:3001',
+          changeOrigin: true,
+        },
+        '/auth': {
+          target: 'http://127.0.0.1:3001',
+          changeOrigin: true,
+        },
       },
     },
     test: {

--- a/packages/bot/.env.example
+++ b/packages/bot/.env.example
@@ -25,6 +25,9 @@ TON_WALLET_ADDRESS=
 TONCENTER_API_KEY=
 TONCENTER_TESTNET=true   # remove in production
 
+# Mapillary (server-side only — token is proxied through /api/mapillary/images)
+MAPILLARY_ACCESS_TOKEN=
+
 # Telegram Login SDK (Bot ID used as JWT audience for id_token verification)
 TELEGRAM_CLIENT_ID=8613521247
 

--- a/packages/bot/src/routes/auth.ts
+++ b/packages/bot/src/routes/auth.ts
@@ -52,24 +52,38 @@ function generateCodeChallenge(verifier: string): string {
   return createHash('sha256').update(verifier).digest('base64url')
 }
 
+const ALLOWED_RETURN_ORIGINS = [
+  'https://trailx.ru',
+  'https://trailx-app.vercel.app',
+  'http://localhost:5173',
+  'http://localhost:4173',
+  'http://localhost:3000',
+  'http://127.0.0.1:3000',
+]
+
 // ── OIDC browser-redirect routes (prefix: /auth) ──────────────────────────────
 
 export const authOidcRoutes: FastifyPluginAsync = async (fastify) => {
   const CLIENT_ID = process.env.TELEGRAM_CLIENT_ID ?? ''
   const CLIENT_SECRET = process.env.TELEGRAM_CLIENT_SECRET ?? ''
   const REDIRECT_URI = process.env.TELEGRAM_OIDC_REDIRECT_URI ?? ''
-  const FRONTEND_URL = process.env.FRONTEND_URL ?? 'http://localhost:5173'
+  const FRONTEND_URL = process.env.FRONTEND_URL ?? 'http://localhost:3000'
 
   // GET /auth/telegram — initiate OIDC Authorization Code flow with PKCE
-  fastify.get('/telegram', async (req, reply) => {
-    const state = randomBytes(16).toString('hex')
+  fastify.get<{ Querystring: { return_to?: string } }>('/telegram', async (req, reply) => {
+    const rawReturnTo = req.query.return_to ?? ''
+    const allowed = [...ALLOWED_RETURN_ORIGINS, FRONTEND_URL].filter(Boolean)
+    const returnTo = allowed.some(o => rawReturnTo.startsWith(o)) ? rawReturnTo : FRONTEND_URL
+
+    const nonce = randomBytes(16).toString('hex')
     const codeVerifier = generateCodeVerifier()
     const codeChallenge = generateCodeChallenge(codeVerifier)
-    const returnTo = (req.headers.origin as string | undefined) ?? FRONTEND_URL
 
-    reply.setCookie('tg_oauth_state', state, STATE_COOKIE_OPTS)
+    // Encode returnTo inside the OAuth state so it survives the redirect without a cookie
+    const state = Buffer.from(JSON.stringify({ nonce, returnTo })).toString('base64url')
+
+    reply.setCookie('tg_oauth_state', nonce, STATE_COOKIE_OPTS)
     reply.setCookie('tg_pkce', codeVerifier, STATE_COOKIE_OPTS)
-    reply.setCookie('tg_return_to', returnTo, STATE_COOKIE_OPTS)
 
     const params = new URLSearchParams({
       client_id: CLIENT_ID,
@@ -90,14 +104,19 @@ export const authOidcRoutes: FastifyPluginAsync = async (fastify) => {
     async (req, reply) => {
       const { code, state, error } = req.query
 
-      const returnToRaw = req.cookies.tg_return_to
-      const returnToResult = returnToRaw ? req.unsignCookie(returnToRaw) : null
-      const returnTo = returnToResult?.valid ? returnToResult.value : FRONTEND_URL
+      // Decode returnTo from the OAuth state param — doesn't rely on a separate cookie
+      let stateData: { nonce?: string; returnTo?: string } = {}
+      try {
+        stateData = JSON.parse(Buffer.from(state ?? '', 'base64url').toString()) as {
+          nonce: string
+          returnTo: string
+        }
+      } catch { /* malformed state → stateData stays empty */ }
+      const returnTo = stateData.returnTo ?? FRONTEND_URL
 
       const clearState = () => {
         reply.clearCookie('tg_oauth_state', { path: '/' })
         reply.clearCookie('tg_pkce', { path: '/' })
-        reply.clearCookie('tg_return_to', { path: '/' })
       }
 
       if (error) {
@@ -105,10 +124,10 @@ export const authOidcRoutes: FastifyPluginAsync = async (fastify) => {
         return reply.redirect(`${returnTo}/?auth=error`)
       }
 
-      // Validate CSRF state
-      const storedStateRaw = req.cookies.tg_oauth_state
-      const storedStateResult = storedStateRaw ? req.unsignCookie(storedStateRaw) : null
-      if (!storedStateResult?.valid || storedStateResult.value !== state || !code) {
+      // CSRF: validate nonce from state against the short-lived cookie
+      const storedNonceRaw = req.cookies.tg_oauth_state
+      const storedNonceResult = storedNonceRaw ? req.unsignCookie(storedNonceRaw) : null
+      if (!storedNonceResult?.valid || storedNonceResult.value !== stateData.nonce || !code) {
         clearState()
         return reply.redirect(`${returnTo}/?auth=error`)
       }

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,10 @@
   "buildCommand": "pnpm --filter app build",
   "outputDirectory": "packages/app/dist",
   "installCommand": "pnpm install",
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "https://trailxbot-production.up.railway.app/api/:path*" },
+    { "source": "/auth/:path*", "destination": "https://trailxbot-production.up.railway.app/auth/:path*" },
+    { "source": "/routes/:path*", "destination": "https://trailxbot-production.up.railway.app/routes/:path*" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
 }


### PR DESCRIPTION
## Changes

**fix(mapillary)**: correct env var name, switch to lat/lng/radius API

**feat(poi)**: image navigation arrows + category icon fallback when no photo available

**feat(poi)**: parallel Mapillary + Wikidata fetch (faster image loading)

**refactor(auth)**: Vercel proxy for all API and auth traffic
- `vercel.json` — `/api/*`, `/auth/*`, `/routes/*` proxied to Railway
- `vite.config.ts` — dev proxy for `/api` and `/auth` → `localhost:3001`
- `api.ts`, `graphhopper.ts`, `useAuth.ts` — relative URLs everywhere, `VITE_API_URL` no longer needed
- `auth.ts` — `return_to` passed as query param, encoded inside OAuth `state` (base64url JSON) so redirect URL survives the Telegram OAuth roundtrip without a separate cookie

**feat(auth)**: official Telegram OIDC login button
- Loads `oauth.telegram.org/js/telegram-login.js` to render the official "Sign In with Telegram" button (`data-style=shine`)
- `onClick` keeps the existing server-side redirect flow (`/auth/telegram?return_to=...`)
- `data-onauth` fallback calls `getMe()` for popup-based auth completion

**test(useAuth)**: update `loginWithTelegram` assertion for `?return_to=` param