### PR TITLE
Migrate geocoding to Photon, add subscription transfer & group routes

### DIFF
--- a/packages/app/src/components/AccountPanel/AccountPanel.tsx
+++ b/packages/app/src/components/AccountPanel/AccountPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { FloppyDisk, TelegramLogo, X } from '@phosphor-icons/react'
-import type { LocalRoute, SavedRouteDTO, BotRouteDTO } from '@trailx/shared'
+import type { LocalRoute, SavedRouteDTO, BotRouteDTO, GroupRouteDTO } from '@trailx/shared'
 import { usePlatform } from '../../hooks/usePlatform'
 import { useTelegramWebApp } from '../../hooks/useTelegramWebApp'
 import { useMapStore } from '../../store/useMapStore'
@@ -18,7 +18,7 @@ export function AccountPanel({ onClose }: AccountPanelProps) {
   const { isTMA } = usePlatform()
   const { webApp } = useTelegramWebApp()
   const { authUser, isLoggedIn, isSimulated, logout, loginWithTelegram } = useAuth()
-  const { savedRoutes, botRoutes, isLoading, isMigrating, saveCurrentRoute, deleteRoute, loadRoute } = useSavedRoutes()
+  const { savedRoutes, botRoutes, groupRoutes, isLoading, isMigrating, saveCurrentRoute, deleteRoute, deleteBotRoute, loadRoute } = useSavedRoutes()
   const localRoutes = useMapStore((s) => s.localRoutes)
   const waypoints = useMapStore((s) => s.waypoints)
 
@@ -173,7 +173,21 @@ export function AccountPanel({ onClose }: AccountPanelProps) {
                     key={r.id}
                     route={r}
                     onLoad={() => { loadRoute(r); onClose?.() }}
-                    readOnly
+                    onDelete={() => deleteBotRoute(r.id)}
+                  />
+                ))}
+              </>
+            )}
+            {groupRoutes.length > 0 && (
+              <>
+                <span className={styles.sectionSubLabel}>Group Routes</span>
+                {groupRoutes.map((r: GroupRouteDTO) => (
+                  <RouteListItem
+                    key={r.id}
+                    route={r}
+                    onLoad={() => { loadRoute(r); onClose?.() }}
+                    onDelete={r.isOwner ? () => deleteBotRoute(r.id) : undefined}
+                    readOnly={!r.isOwner}
                   />
                 ))}
               </>

--- a/packages/app/src/hooks/useAuth.test.ts
+++ b/packages/app/src/hooks/useAuth.test.ts
@@ -21,7 +21,7 @@ const mockUseMapStore = vi.mocked(useMapStore)
 
 const MOCK_USER = {
   id: 'user-1',
-  telegramId: 12345,
+  telegramId: '12345',
   name: 'Alice',
   username: 'alice',
   avatarUrl: undefined,

--- a/packages/app/src/hooks/useAuth.ts
+++ b/packages/app/src/hooks/useAuth.ts
@@ -15,7 +15,7 @@ export interface UseAuthReturn {
 
 const SIMULATED_USER: AuthUser = {
   id: 'debug-user-123',
-  telegramId: 123456789,
+  telegramId: '123456789',
   name: 'Debug User',
   username: 'debuguser',
   avatarUrl: undefined,

--- a/packages/app/src/hooks/useSavedRoutes.test.ts
+++ b/packages/app/src/hooks/useSavedRoutes.test.ts
@@ -123,9 +123,11 @@ describe('useSavedRoutes', () => {
       setupMockStore({ debugSimulateAuth: true })
     })
 
-    it('returns 3 mock routes', () => {
+    it('returns mock routes for each category', () => {
       const { result } = renderHook(() => useSavedRoutes())
-      expect(result.current.savedRoutes).toHaveLength(3)
+      expect(result.current.savedRoutes).toHaveLength(1)
+      expect(result.current.botRoutes).toHaveLength(1)
+      expect(result.current.groupRoutes).toHaveLength(1)
     })
 
     it('isLoading is false immediately', () => {

--- a/packages/app/src/hooks/useSavedRoutes.ts
+++ b/packages/app/src/hooks/useSavedRoutes.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import type { SavedRouteDTO, SaveRoutePayload, LocalRoute, BotRouteDTO } from '@trailx/shared'
+import type { SavedRouteDTO, SaveRoutePayload, LocalRoute, BotRouteDTO, GroupRouteDTO } from '@trailx/shared'
 import type { RoutePoint } from '@trailx/shared'
 import { usePlatform } from './usePlatform'
 import { useTelegramWebApp } from './useTelegramWebApp'
@@ -7,19 +7,23 @@ import { useMapStore } from '../store/useMapStore'
 import {
   listSavedRoutes,
   listUserBotRoutes,
+  listGroupRoutes,
   createSavedRoute,
   deleteSavedRoute as apiDeleteSavedRoute,
+  deleteBotRoute as apiDeleteBotRoute,
 } from '../services/api'
 
 export interface UseSavedRoutesReturn {
   savedRoutes: SavedRouteDTO[]
   botRoutes: BotRouteDTO[]
+  groupRoutes: GroupRouteDTO[]
   isLoading: boolean
   error: string | null
   isMigrating: boolean
   saveCurrentRoute: (name: string) => Promise<void>
   deleteRoute: (id: string) => Promise<void>
-  loadRoute: (route: SavedRouteDTO | LocalRoute | BotRouteDTO) => void
+  deleteBotRoute: (id: string) => Promise<void>
+  loadRoute: (route: SavedRouteDTO | LocalRoute | BotRouteDTO | GroupRouteDTO) => void
 }
 
 function normaliseBotWaypoints(raw: unknown[]): RoutePoint[] {
@@ -48,6 +52,7 @@ export function useSavedRoutes(): UseSavedRoutesReturn {
 
   const [savedRoutes, setSavedRoutes] = useState<SavedRouteDTO[]>([])
   const [botRoutes, setBotRoutes] = useState<BotRouteDTO[]>([])
+  const [groupRoutes, setGroupRoutes] = useState<GroupRouteDTO[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [isMigrating, setIsMigrating] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -68,35 +73,6 @@ export function useSavedRoutes(): UseSavedRoutesReturn {
       createdAt: new Date(Date.now() - 86400000 * 2).toISOString(),
       updatedAt: new Date(Date.now() - 86400000 * 2).toISOString(),
     },
-    {
-      id: 'mock-route-2',
-      name: 'Morning Ride: Lakes Loop',
-      waypoints: [
-        { id: 'wp4', lat: 53.8891, lng: 27.6748, order: 0, type: 'start', label: 'Zaslonava' },
-        { id: 'wp5', lat: 53.8765, lng: 27.7210, order: 1, type: 'intermediate', label: 'Water Reservoir' },
-        { id: 'wp6', lat: 53.8891, lng: 27.6748, order: 2, type: 'end', label: 'Zaslonava' },
-      ],
-      distanceKm: 12.3,
-      elevationM: 78,
-      profileId: 'racingbike',
-      createdAt: new Date(Date.now() - 86400000 * 5).toISOString(),
-      updatedAt: new Date(Date.now() - 86400000 * 5).toISOString(),
-    },
-    {
-      id: 'mock-route-3',
-      name: 'Weekend MTB Trail',
-      waypoints: [
-        { id: 'wp7', lat: 53.9342, lng: 27.5934, order: 0, type: 'start', label: 'Forest Entrance' },
-        { id: 'wp8', lat: 53.9456, lng: 27.6123, order: 1, type: 'intermediate', label: 'Lake View' },
-        { id: 'wp9', lat: 53.9512, lng: 27.6345, order: 2, type: 'intermediate', label: 'Hill Top' },
-        { id: 'wp10', lat: 53.9342, lng: 27.5934, order: 3, type: 'end', label: 'Forest Exit' },
-      ],
-      distanceKm: 18.7,
-      elevationM: 156,
-      profileId: 'mtb',
-      createdAt: new Date(Date.now() - 86400000 * 8).toISOString(),
-      updatedAt: new Date(Date.now() - 86400000 * 8).toISOString(),
-    },
   ]
 
   const mockBotRoutes: BotRouteDTO[] = [
@@ -113,8 +89,11 @@ export function useSavedRoutes(): UseSavedRoutesReturn {
       createdAt: new Date(Date.now() - 86400000 * 3).toISOString(),
       updatedAt: new Date(Date.now() - 86400000 * 3).toISOString(),
     },
+  ]
+
+  const mockGroupRoutes: GroupRouteDTO[] = [
     {
-      id: 'mock-bot-route-2',
+      id: 'mock-group-route-1',
       name: 'Велопоход по Налибокам',
       waypoints: [
         { lat: 53.6512, lng: 26.3240, label: 'Воложин', order: 0 },
@@ -122,7 +101,9 @@ export function useSavedRoutes(): UseSavedRoutesReturn {
       ],
       distanceKm: null,
       elevationM: null,
-      groupId: 'mock-group-1',
+      groupId: 'mock-group-2',
+      groupChatId: '-1001234567890',
+      isOwner: false,
       createdAt: new Date(Date.now() - 86400000 * 10).toISOString(),
       updatedAt: new Date(Date.now() - 86400000 * 10).toISOString(),
     },
@@ -139,6 +120,7 @@ export function useSavedRoutes(): UseSavedRoutesReturn {
     if (debugSimulateAuth) {
       setSavedRoutes(mockRoutes)
       setBotRoutes(mockBotRoutes)
+      setGroupRoutes(mockGroupRoutes)
       setIsLoading(false)
       setIsMigrating(false)
       return
@@ -147,6 +129,7 @@ export function useSavedRoutes(): UseSavedRoutesReturn {
     if (!authUser) {
       setSavedRoutes([])
       setBotRoutes([])
+      setGroupRoutes([])
       return
     }
 
@@ -156,18 +139,21 @@ export function useSavedRoutes(): UseSavedRoutesReturn {
 
     async function fetchAndMigrate() {
       try {
-        const [savedResult, botResult] = await Promise.allSettled([
+        const [savedResult, botResult, groupResult] = await Promise.allSettled([
           listSavedRoutes(buildAuthHeader()),
           listUserBotRoutes(buildAuthHeader()),
+          listGroupRoutes(buildAuthHeader()),
         ])
 
         if (cancelled) return
 
         const saved = savedResult.status === 'fulfilled' ? savedResult.value : []
         const bot = botResult.status === 'fulfilled' ? botResult.value : []
+        const group = groupResult.status === 'fulfilled' ? groupResult.value : []
 
         setSavedRoutes(saved)
         setBotRoutes(bot)
+        setGroupRoutes(group)
 
         if (savedResult.status === 'rejected') {
           setError(savedResult.reason instanceof Error ? savedResult.reason.message : 'Failed to load routes')
@@ -247,7 +233,12 @@ export function useSavedRoutes(): UseSavedRoutesReturn {
     setSavedRoutes((prev) => prev.filter((r) => r.id !== id))
   }, [authUser, isTMA, webApp, removeLocalRoute])
 
-  const loadRoute = useCallback((route: SavedRouteDTO | LocalRoute | BotRouteDTO) => {
+  const deleteBotRoute = useCallback(async (id: string) => {
+    await apiDeleteBotRoute(id, buildAuthHeader())
+    setBotRoutes((prev) => prev.filter((r) => r.id !== id))
+  }, [isTMA, webApp])
+
+  const loadRoute = useCallback((route: SavedRouteDTO | LocalRoute | BotRouteDTO | GroupRouteDTO) => {
     let points: RoutePoint[]
 
     if ('groupId' in route) {
@@ -275,5 +266,5 @@ export function useSavedRoutes(): UseSavedRoutesReturn {
     setAccountOpen(false)
   }, [setWaypoints, setAccountOpen])
 
-  return { savedRoutes, botRoutes, isLoading, error, isMigrating, saveCurrentRoute, deleteRoute, loadRoute }
+  return { savedRoutes, botRoutes, groupRoutes, isLoading, error, isMigrating, saveCurrentRoute, deleteRoute, deleteBotRoute, loadRoute }
 }

--- a/packages/app/src/services/api.ts
+++ b/packages/app/src/services/api.ts
@@ -1,4 +1,4 @@
-import type { SessionPayload, CreateSessionResponse, GetSessionResponse, AuthUser, SavedRouteDTO, SaveRoutePayload, BotRouteDTO } from '@trailx/shared'
+import type { SessionPayload, CreateSessionResponse, GetSessionResponse, AuthUser, SavedRouteDTO, SaveRoutePayload, BotRouteDTO, GroupRouteDTO } from '@trailx/shared'
 
 const API_BASE = (import.meta as ImportMeta & { env: Record<string, string> }).env
   .VITE_API_URL ?? ''
@@ -134,4 +134,37 @@ export async function renameSavedRoute(id: string, name: string, authHeader: Tma
   })
   if (!res.ok) throw new Error(`renameSavedRoute failed: ${res.status}`)
   return res.json() as Promise<SavedRouteDTO>
+}
+
+export async function listGroupRoutes(authHeader: TmaHeader = {}): Promise<GroupRouteDTO[]> {
+  const res = await fetch(`${API_BASE}/api/group-routes`, {
+    credentials: 'include',
+    headers: authHeader,
+  })
+  if (!res.ok) throw new Error(`listGroupRoutes failed: ${res.status}`)
+  return res.json() as Promise<GroupRouteDTO[]>
+}
+
+export async function updateBotRoute(
+  id: string,
+  body: { name?: string; waypoints?: unknown[] },
+  authHeader: TmaHeader = {},
+): Promise<BotRouteDTO> {
+  const res = await fetch(`${API_BASE}/api/user-bot-routes/${id}`, {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', ...authHeader },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(`updateBotRoute failed: ${res.status}`)
+  return res.json() as Promise<BotRouteDTO>
+}
+
+export async function deleteBotRoute(id: string, authHeader: TmaHeader = {}): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/user-bot-routes/${id}`, {
+    method: 'DELETE',
+    credentials: 'include',
+    headers: authHeader,
+  })
+  if (!res.ok) throw new Error(`deleteBotRoute failed: ${res.status}`)
 }

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@fastify/cookie": "^9.4.0",
     "@fastify/cors": "^9.0.1",
+    "@fastify/rate-limit": "^10.3.0",
     "@fastify/websocket": "^10.0.1",
     "@prisma/client": "^5.22.0",
     "@sentry/node": "^10.47.0",

--- a/packages/bot/prisma/schema.prisma
+++ b/packages/bot/prisma/schema.prisma
@@ -8,12 +8,26 @@ datasource db {
 }
 
 model Group {
-  id            String   @id
-  chatId        BigInt   @unique
-  isPro         Boolean  @default(false)
+  id            String        @id
+  chatId        BigInt        @unique
+  isPro         Boolean       @default(false)
   activeRouteId String?
-  createdAt     DateTime @default(now())
+  createdAt     DateTime      @default(now())
   routes        Route[]
+  members       GroupMember[]
+}
+
+model GroupMember {
+  id         String   @id @default(cuid())
+  groupId    String
+  group      Group    @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  telegramId BigInt
+  status     String   @default("member") // 'member' | 'administrator' | 'creator' | 'left' | 'kicked'
+  updatedAt  DateTime @updatedAt
+  createdAt  DateTime @default(now())
+
+  @@unique([groupId, telegramId])
+  @@index([telegramId])
 }
 
 model Route {
@@ -137,15 +151,16 @@ model WebSession {
 
 // Subscription plans — dynamic pricing from DB
 model Plan {
-  id String @id // 'monthly' | 'annual'
-  label String // '1 месяц' | '1 год'
-  description String // описание подписки
-  days Int // срок в днях
-  isActive Boolean @default(true)
-  sortOrder Int @default(0) // для сортировки в UI
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  pricing ProviderPricing[]
+  id           String   @id // 'monthly' | 'annual'
+  label        String   // '1 месяц' | '1 год'
+  description  String   // описание подписки
+  days         Int      // срок в днях
+  priceDisplay String?  // ориентировочная цена для UI, например "$5"
+  isActive     Boolean  @default(true)
+  sortOrder    Int      @default(0) // для сортировки в UI
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  pricing      ProviderPricing[]
 }
 
 // Provider-specific pricing for each plan

--- a/packages/bot/prisma/schema.prisma
+++ b/packages/bot/prisma/schema.prisma
@@ -56,6 +56,8 @@ model Subscription {
   provider                String?  // "stars" | "ton" | "webpay"
   telegramPaymentChargeId String?  @unique
   providerPaymentChargeId String?
+  linkedGroupChatId       BigInt?
+  reminderSentAt          DateTime?
   expiresAt               DateTime
   createdAt               DateTime @default(now())
   updatedAt               DateTime @updatedAt

--- a/packages/bot/src/commands/add.ts
+++ b/packages/bot/src/commands/add.ts
@@ -2,7 +2,7 @@ import type { Bot, Context } from 'grammy'
 import { InlineKeyboard } from 'grammy'
 import type { Prisma } from '@prisma/client'
 import { prisma } from '../db'
-import { geocode, type GeocodedPlace } from '../services/geocode'
+import { geocode, reverseGeocode, type GeocodedPlace } from '../services/geocode'
 import { broadcastRouteUpdate } from '../ws/hub'
 import { requireSubscription } from '../middleware/requireSubscription'
 import type { StoredWaypoint } from '../types'
@@ -50,13 +50,22 @@ async function doSearch(
   await ctx.reply(`Найдено ${count} ${word}. Выбери нужное:`, { reply_markup: kb })
 }
 
+// Pattern: "52.0977 23.7341" or "52.0977,23.7341"
+const COORD_RE = /^\s*(-?\d{1,3}(?:\.\d+)?)\s*[, ]\s*(-?\d{1,3}(?:\.\d+)?)\s*$/
+
 export function registerAdd(bot: Bot<Context>): void {
   // ── /add command ──────────────────────────────────────────────────────────
   bot.command('add', requireSubscription, async (ctx) => {
     try {
       const place = ctx.match.trim()
       if (!place) {
-        await ctx.reply('Использование: /add <место>\nПример: /add Брест вокзал')
+        await ctx.reply(
+          'Использование:\n' +
+          '/add <место> — поиск по названию\n' +
+          '/add <широта> <долгота> — добавить по координатам\n\n' +
+          'Пример: /add Брест вокзал\n' +
+          'Пример: /add 52.0977 23.7341',
+        )
         return
       }
 
@@ -76,6 +85,34 @@ export function registerAdd(bot: Bot<Context>): void {
       }
 
       const waypoints = route.waypoints as unknown as StoredWaypoint[]
+
+      // ── Coordinate input shortcut ─────────────────────────────────────────
+      const coordMatch = place.match(COORD_RE)
+      if (coordMatch) {
+        const lat = parseFloat(coordMatch[1])
+        const lng = parseFloat(coordMatch[2])
+        if (lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180) {
+          const label = (await reverseGeocode(lat, lng)) ?? `${lat}, ${lng}`
+          const newWaypoint: StoredWaypoint = {
+            lat,
+            lng,
+            label,
+            order: waypoints.length,
+          }
+          const updated = [...waypoints, newWaypoint]
+          await prisma.route.update({
+            where: { id: routeId },
+            data: { waypoints: updated as unknown as Prisma.InputJsonValue },
+          })
+          broadcastRouteUpdate(chatId.toString(), routeId, updated)
+          await ctx.reply(
+            `✅ *${label}* добавлен в маршрут!\nТочек в маршруте: ${updated.length}`,
+            { parse_mode: 'Markdown' },
+          )
+          return
+        }
+      }
+
       await doSearch(ctx, place, routeId, waypoints)
     } catch (err) {
       console.error('[/add]', err)

--- a/packages/bot/src/commands/add.ts
+++ b/packages/bot/src/commands/add.ts
@@ -4,8 +4,20 @@ import type { Prisma } from '@prisma/client'
 import { prisma } from '../db'
 import { geocode, reverseGeocode, type GeocodedPlace } from '../services/geocode'
 import { broadcastRouteUpdate } from '../ws/hub'
-import { requireSubscription } from '../middleware/requireSubscription'
 import type { StoredWaypoint } from '../types'
+
+const FREE_TIER_LIMIT = 3
+
+async function isProUser(chatId: bigint, userId: bigint): Promise<boolean> {
+  const groupSub = await prisma.subscription.findFirst({
+    where: { chatId, status: 'active', expiresAt: { gt: new Date() } },
+  })
+  if (groupSub) return true
+  const personalSub = await prisma.subscription.findFirst({
+    where: { chatId: userId, status: 'active', expiresAt: { gt: new Date() } },
+  })
+  return !!personalSub
+}
 
 // ── In-memory result cache (10 min TTL) ─────────────────────────────────────
 // Avoids encoding full place data in callback_data (64-byte Telegram limit).
@@ -55,7 +67,7 @@ const COORD_RE = /^\s*(-?\d{1,3}(?:\.\d+)?)\s*[, ]\s*(-?\d{1,3}(?:\.\d+)?)\s*$/
 
 export function registerAdd(bot: Bot<Context>): void {
   // ── /add command ──────────────────────────────────────────────────────────
-  bot.command('add', requireSubscription, async (ctx) => {
+  bot.command('add', async (ctx) => {
     try {
       const place = ctx.match.trim()
       if (!place) {
@@ -85,6 +97,16 @@ export function registerAdd(bot: Bot<Context>): void {
       }
 
       const waypoints = route.waypoints as unknown as StoredWaypoint[]
+      const userId = BigInt(ctx.from?.id ?? ctx.chat.id)
+
+      // ── Free-tier limit check ─────────────────────────────────────────────
+      if (waypoints.length >= FREE_TIER_LIMIT && !(await isProUser(chatId, userId))) {
+        await ctx.reply(
+          `⚠️ Бесплатный план позволяет добавить до ${FREE_TIER_LIMIT} точек в маршрут.\n\n` +
+          'Оформи TrailX Pro через /upgrade для неограниченного количества точек.',
+        )
+        return
+      }
 
       // ── Coordinate input shortcut ─────────────────────────────────────────
       const coordMatch = place.match(COORD_RE)
@@ -145,6 +167,16 @@ export function registerAdd(bot: Bot<Context>): void {
       }
 
       const waypoints = route.waypoints as unknown as StoredWaypoint[]
+      const userId = BigInt(ctx.from?.id ?? ctx.chat!.id)
+
+      if (waypoints.length >= FREE_TIER_LIMIT && !(await isProUser(chatId, userId))) {
+        await ctx.editMessageText(
+          `⚠️ Бесплатный план позволяет добавить до ${FREE_TIER_LIMIT} точек в маршрут.\n\n` +
+          'Оформи TrailX Pro через /upgrade для неограниченного количества точек.',
+        )
+        return
+      }
+
       const newWaypoint: StoredWaypoint = {
         lat: place.lat,
         lng: place.lng,

--- a/packages/bot/src/commands/chatMember.ts
+++ b/packages/bot/src/commands/chatMember.ts
@@ -1,7 +1,28 @@
 import type { Bot, Context } from 'grammy'
 import { prisma } from '../db'
 
+/**
+ * Upsert a user's membership record for a group.
+ * Safe to call on every group interaction — uses upsert to avoid duplicates.
+ */
+export async function upsertGroupMember(
+  groupId: string,
+  telegramId: bigint,
+  status: string = 'member',
+): Promise<void> {
+  try {
+    await prisma.groupMember.upsert({
+      where: { groupId_telegramId: { groupId, telegramId } },
+      create: { groupId, telegramId, status },
+      update: { status, updatedAt: new Date() },
+    })
+  } catch (err) {
+    console.error('[upsertGroupMember]', err)
+  }
+}
+
 export function registerChatMember(bot: Bot<Context>): void {
+  // ── Bot join / leave ───────────────────────────────────────────────────────
   bot.on('my_chat_member', async (ctx) => {
     try {
       const update = ctx.myChatMember
@@ -9,7 +30,6 @@ export function registerChatMember(bot: Bot<Context>): void {
       const chatId = BigInt(update.chat.id)
 
       if (newStatus === 'member' || newStatus === 'administrator') {
-        // Bot was added to a group — ensure Group record exists
         await prisma.group.upsert({
           where: { chatId },
           create: { id: chatId.toString(), chatId },
@@ -21,6 +41,26 @@ export function registerChatMember(bot: Bot<Context>): void {
       }
     } catch (err) {
       console.error('[my_chat_member]', err)
+    }
+  })
+
+  // ── User join / leave — track GroupMember ─────────────────────────────────
+  bot.on('chat_member', async (ctx) => {
+    try {
+      const update = ctx.chatMember
+      const chatId = BigInt(update.chat.id)
+      const userId = BigInt(update.new_chat_member.user.id)
+      const newStatus = update.new_chat_member.status
+
+      const group = await prisma.group.findUnique({
+        where: { chatId },
+        select: { id: true },
+      })
+      if (!group) return
+
+      await upsertGroupMember(group.id, userId, newStatus)
+    } catch (err) {
+      console.error('[chat_member]', err)
     }
   })
 }

--- a/packages/bot/src/commands/index.ts
+++ b/packages/bot/src/commands/index.ts
@@ -1,4 +1,5 @@
 import type { Bot, Context } from 'grammy'
+import { prisma } from '../db'
 import { registerPaymentHandlers } from '../payments'
 import { registerStart } from './start'
 import { registerPlan } from './plan'
@@ -12,9 +13,27 @@ import { registerSocial } from './social'
 import { registerUpgrade } from './upgrade'
 import { registerHelp } from './help'
 import { registerInlineQuery } from './inlineQuery'
-import { registerChatMember } from './chatMember'
+import { registerChatMember, upsertGroupMember } from './chatMember'
 
 export function registerCommands(bot: Bot<Context>): void {
+  // ── Group membership tracking middleware ──────────────────────────────────
+  // Captures any user who sends a message/callback in a known group, so that
+  // group routes can be shown to them in the web app without relying solely
+  // on Telegram's chat_member events (which require explicit allowance).
+  bot.use(async (ctx, next) => {
+    if (ctx.from && ctx.chat && ctx.chat.type !== 'private') {
+      const chatId = BigInt(ctx.chat.id)
+      const group = await prisma.group.findUnique({
+        where: { chatId },
+        select: { id: true },
+      })
+      if (group) {
+        void upsertGroupMember(group.id, BigInt(ctx.from.id))
+      }
+    }
+    return next()
+  })
+
   registerStart(bot)
   registerPlan(bot)
   registerMyRoutes(bot)

--- a/packages/bot/src/commands/inlineQuery.ts
+++ b/packages/bot/src/commands/inlineQuery.ts
@@ -1,58 +1,46 @@
 import type { Bot, Context } from 'grammy'
-import type { InlineQueryResultArticle } from 'grammy/types'
-import { prisma } from '../db'
+import { InlineKeyboard } from 'grammy'
+import { getPlanSafe } from '../services/pricing'
+import type { PlanId } from '../payments/plans'
 
 export function registerInlineQuery(bot: Bot<Context>): void {
   bot.on('inline_query', async (ctx) => {
     try {
       const query = ctx.inlineQuery.query.trim()
-      const userId = ctx.inlineQuery.from.id
 
-      // Resolve groups the user belongs to (check membership via Telegram API)
-      const groups = await prisma.group.findMany({ select: { id: true, chatId: true } })
+      // Subscription transfer: query = "transfer:{userId}:{planId}"
+      const transferMatch = query.match(/^transfer:(\d+):(monthly|annual)$/)
+      if (transferMatch) {
+        const [, userId, planId] = transferMatch
+        const plan = await getPlanSafe(planId as PlanId)
+        const priceHint = plan.priceDisplay ? ` — ${plan.priceDisplay}` : ''
 
-      const memberGroupIds = (await Promise.allSettled(
-        groups.map(async (g) => {
-          const member = await ctx.api.getChatMember(Number(g.chatId), userId)
-          if (['member', 'administrator', 'creator'].includes(member.status)) {
-            return g.id
-          }
-          return null
-        }),
-      ))
-        .filter((r): r is PromiseFulfilledResult<string> =>
-          r.status === 'fulfilled' && r.value !== null,
+        const confirmKb = new InlineKeyboard()
+          .text('✅ Подтвердить активацию', `confirm_transfer:${userId}:${planId}`)
+
+        await ctx.answerInlineQuery(
+          [
+            {
+              type: 'article' as const,
+              id: 'activate',
+              title: '✅ Активировать TrailX Pro для этой группы',
+              description: `План: ${plan.label}${priceHint}`,
+              input_message_content: {
+                message_text:
+                  `🎉 <b>TrailX Pro</b> — запрос на активацию!\n` +
+                  `📦 План: ${plan.label}${priceHint}\n\n` +
+                  `Нажми кнопку ниже для подтверждения.`,
+                parse_mode: 'HTML' as const,
+              },
+              reply_markup: confirmKb,
+            },
+          ],
+          { cache_time: 0 },
         )
-        .map((r) => r.value)
-
-      if (memberGroupIds.length === 0) {
-        await ctx.answerInlineQuery([], { cache_time: 60 })
         return
       }
 
-      const routes = await prisma.route.findMany({
-        where: {
-          groupId: { in: memberGroupIds },
-          ...(query ? { name: { contains: query, mode: 'insensitive' as const } } : {}),
-        },
-        orderBy: { updatedAt: 'desc' },
-        take: 5,
-      })
-
-      const results: InlineQueryResultArticle[] = routes.map((r) => ({
-        type: 'article' as const,
-        id: r.id,
-        title: r.name ?? r.id,
-        description: `Точек: ${(r.waypoints as unknown[]).length}`,
-        input_message_content: {
-          message_text:
-            `🗺 *${r.name ?? 'Маршрут'}*\n` +
-            `Точек: ${(r.waypoints as unknown[]).length}`,
-          parse_mode: 'Markdown' as const,
-        },
-      }))
-
-      await ctx.answerInlineQuery(results, { cache_time: 300 })
+      await ctx.answerInlineQuery([], { cache_time: 60 })
     } catch (err) {
       console.error('[inline_query]', err)
       await ctx.answerInlineQuery([], { cache_time: 0 })

--- a/packages/bot/src/commands/upgrade.ts
+++ b/packages/bot/src/commands/upgrade.ts
@@ -17,7 +17,6 @@ import {
 import {
   getPlans,
   getPlanSafe,
-  getPricingForProviderSafe,
 } from '../services/pricing'
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -54,25 +53,11 @@ async function planKeyboard(): Promise<InlineKeyboard> {
   const kb = new InlineKeyboard()
 
   for (const plan of plans) {
-    const providers = getAvailableProviders()
-    let displayPrice = ''
-
-    for (const provider of providers) {
-      const supports = await provider.supportsPlan?.(plan.id)
-      if (supports !== false) {
-        const pricing = await getPricingForProviderSafe(plan.id, provider.id)
-        if (pricing) {
-          displayPrice = pricing.displayAmount
-          break
-        }
-      }
-    }
-
+    const price = plan.priceDisplay ?? ''
     const prefix = plan.id === 'annual' ? '🔥' : '✅'
-    const label = displayPrice
-      ? `${prefix} ${plan.label} — ${displayPrice}`
+    const label = price
+      ? `${prefix} ${plan.label} — ${price}`
       : `${prefix} ${plan.label}`
-
     kb.text(label, `pay:${plan.id}`).row()
   }
 
@@ -504,5 +489,66 @@ export function registerUpgrade(bot: Bot<Context>): void {
   bot.callbackQuery('sub:cancel_abort', async (ctx) => {
     await ctx.answerCallbackQuery('Подписка сохранена 👍')
     await ctx.reply('👍 Подписка сохранена.')
+  })
+
+  // ── Subscription transfer: confirm in group context ───────────────────────
+  bot.callbackQuery(/^confirm_transfer:(\d+):(monthly|annual)$/, async (ctx) => {
+    await ctx.answerCallbackQuery()
+    const userId = BigInt(ctx.match[1])
+    const planId = ctx.match[2] as PlanId
+    const groupChatId = BigInt(ctx.chat?.id ?? 0)
+    const confirmerId = BigInt(ctx.from?.id ?? 0)
+
+    // Only the buyer can confirm
+    if (confirmerId !== userId) {
+      await ctx.answerCallbackQuery('⚠️ Только покупатель может активировать подписку.')
+      return
+    }
+
+    try {
+      // Find subscription bought in a private chat (chatId == userId)
+      const sub = await prisma.subscription.findFirst({
+        where: { userId, chatId: userId, status: 'active' },
+      })
+      if (!sub) {
+        await ctx.reply('⚠️ Активная личная подписка не найдена.')
+        return
+      }
+
+      const existing = await getActiveSub(groupChatId)
+      if (existing?.status === 'active') {
+        await ctx.reply('ℹ️ У этой группы уже есть активная подписка.')
+        return
+      }
+
+      await prisma.$transaction([
+        // Move subscription chatId to the group
+        prisma.subscription.update({ where: { id: sub.id }, data: { chatId: groupChatId } }),
+        // Remove isPro from the old private "group" record
+        prisma.group.updateMany({ where: { chatId: userId }, data: { isPro: false } }),
+        // Activate Pro for the target group
+        prisma.group.upsert({
+          where: { chatId: groupChatId },
+          create: { id: groupChatId.toString(), chatId: groupChatId, isPro: true },
+          update: { isPro: true },
+        }),
+      ])
+
+      const plan = await getPlanSafe(planId)
+      const expiryStr = sub.expiresAt.toLocaleDateString('ru-RU', {
+        day: '2-digit', month: '2-digit', year: 'numeric',
+      })
+
+      await ctx.reply(
+        `🎉 <b>TrailX Pro</b> активирован для этой группы!\n\n` +
+        `📦 План: ${plan.label}\n` +
+        `📅 Действует до: <b>${expiryStr}</b>\n\n` +
+        `Доступны: /add, /vote, /gpx, /weather.`,
+        { parse_mode: 'HTML' },
+      )
+    } catch (err) {
+      console.error('[confirm_transfer]', err)
+      await ctx.reply('⚠️ Ошибка при передаче подписки. Попробуй позже.')
+    }
   })
 }

--- a/packages/bot/src/commands/upgrade.ts
+++ b/packages/bot/src/commands/upgrade.ts
@@ -493,7 +493,9 @@ export function registerUpgrade(bot: Bot<Context>): void {
 
   // ── Subscription transfer: confirm in group context ───────────────────────
   bot.callbackQuery(/^confirm_transfer:(\d+):(monthly|annual)$/, async (ctx) => {
+    // Answer immediately — must happen within 10s and before any DB work
     await ctx.answerCallbackQuery()
+
     const userId = BigInt(ctx.match[1])
     const planId = ctx.match[2] as PlanId
     const groupChatId = BigInt(ctx.chat?.id ?? 0)
@@ -501,17 +503,24 @@ export function registerUpgrade(bot: Bot<Context>): void {
 
     // Only the buyer can confirm
     if (confirmerId !== userId) {
-      await ctx.answerCallbackQuery('⚠️ Только покупатель может активировать подписку.')
+      await ctx.reply('⚠️ Только покупатель может активировать подписку.')
       return
     }
 
     try {
-      // Find subscription bought in a private chat (chatId == userId)
+      // Find personal subscription (chatId == userId, not yet linked to a group)
       const sub = await prisma.subscription.findFirst({
-        where: { userId, chatId: userId, status: 'active' },
+        where: { userId, chatId: userId, status: 'active', linkedGroupChatId: null },
       })
       if (!sub) {
-        await ctx.reply('⚠️ Активная личная подписка не найдена.')
+        const linked = await prisma.subscription.findFirst({
+          where: { userId, chatId: userId, status: 'active' },
+        })
+        if (linked?.linkedGroupChatId) {
+          await ctx.reply('ℹ️ Подписка уже привязана к группе. Передать её в другую группу нельзя.')
+        } else {
+          await ctx.reply('⚠️ Активная личная подписка не найдена.')
+        }
         return
       }
 
@@ -521,11 +530,30 @@ export function registerUpgrade(bot: Bot<Context>): void {
         return
       }
 
+      // COPY model: personal sub stays active, create a new group sub with same expiry
       await prisma.$transaction([
-        // Move subscription chatId to the group
-        prisma.subscription.update({ where: { id: sub.id }, data: { chatId: groupChatId } }),
-        // Remove isPro from the old private "group" record
-        prisma.group.updateMany({ where: { chatId: userId }, data: { isPro: false } }),
+        // Mark personal sub as linked (prevents re-transfer)
+        prisma.subscription.update({
+          where: { id: sub.id },
+          data: { linkedGroupChatId: groupChatId },
+        }),
+        // Create a new subscription for the group (copy of personal)
+        prisma.subscription.create({
+          data: {
+            chatId: groupChatId,
+            userId,
+            plan: sub.plan,
+            status: 'active',
+            provider: sub.provider,
+            amount: sub.amount,
+            currency: sub.currency,
+            telegramPaymentChargeId: sub.telegramPaymentChargeId
+              ? `${sub.telegramPaymentChargeId}_group`
+              : null,
+            providerPaymentChargeId: sub.providerPaymentChargeId,
+            expiresAt: sub.expiresAt,
+          },
+        }),
         // Activate Pro for the target group
         prisma.group.upsert({
           where: { chatId: groupChatId },
@@ -543,7 +571,8 @@ export function registerUpgrade(bot: Bot<Context>): void {
         `🎉 <b>TrailX Pro</b> активирован для этой группы!\n\n` +
         `📦 План: ${plan.label}\n` +
         `📅 Действует до: <b>${expiryStr}</b>\n\n` +
-        `Доступны: /add, /vote, /gpx, /weather.`,
+        `Доступны: /add, /vote, /gpx, /weather.\n\n` +
+        `💡 Твоя личная подписка также остаётся активной.`,
         { parse_mode: 'HTML' },
       )
     } catch (err) {

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node'
 import Fastify from 'fastify'
 import cors from '@fastify/cors'
 import cookie from '@fastify/cookie'
+import rateLimit from '@fastify/rate-limit'
 import rawBody from 'fastify-raw-body'
 import websocket from '@fastify/websocket'
 import { Bot } from 'grammy'
@@ -71,6 +72,15 @@ await fastify.register(cookie, {
 
 await fastify.register(rawBody)
 await fastify.register(websocket)
+await fastify.register(rateLimit, {
+  max: 60,
+  timeWindow: '1 minute',
+  keyGenerator: (req) => {
+    const initData = req.headers['x-telegram-initdata']
+    if (typeof initData === 'string' && initData) return initData.slice(0, 64)
+    return req.ip
+  },
+})
 
 // Sentry error handler — must be registered before routes
 Sentry.setupFastifyErrorHandler(fastify)
@@ -160,21 +170,59 @@ setInterval(async () => {
   if (count > 0) console.log(`Cleaned up ${count} expired sessions`)
 }, 60 * 60 * 1000)
 
+// Daily expiry reminder — notify 7 days before subscription expires
+setInterval(async () => {
+  const now = new Date()
+  const in7days = new Date(now.getTime() + 7 * 86400_000)
+  try {
+    const subs = await prisma.subscription.findMany({
+      where: {
+        status: 'active',
+        expiresAt: { lte: in7days, gte: now },
+        reminderSentAt: null,
+      },
+    })
+    for (const sub of subs) {
+      try {
+        await bot.api.sendMessage(
+          Number(sub.chatId),
+          `⏰ Подписка <b>TrailX Pro</b> истекает ${sub.expiresAt.toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: 'numeric' })}.\n\nПродли её через /upgrade.`,
+          { parse_mode: 'HTML' },
+        )
+        await prisma.subscription.update({
+          where: { id: sub.id },
+          data: { reminderSentAt: now },
+        })
+      } catch {
+        // Bot may be blocked — ignore silently
+      }
+    }
+  } catch (err) {
+    console.error('[expiry-reminder] error:', err)
+  }
+}, 24 * 60 * 60 * 1000)
+
 // Graceful shutdown — flush Sentry events before exit
 process.on('SIGTERM', async () => {
   await Sentry.close(2000)
   process.exit(0)
 })
 
+const ALLOWED_UPDATES = [
+  'message', 'callback_query', 'pre_checkout_query',
+  'poll', 'poll_answer', 'inline_query',
+  'my_chat_member', 'chat_member', 'chosen_inline_result',
+] as const
+
 if (WEBHOOK_DOMAIN) {
   const webhookUrl = `${WEBHOOK_DOMAIN}/webhook/bot`
   await bot.api.setWebhook(webhookUrl, {
     secret_token: WEBHOOK_SECRET || undefined,
-    allowed_updates: ['message', 'callback_query', 'pre_checkout_query', 'poll', 'poll_answer', 'inline_query', 'my_chat_member'],
+    allowed_updates: ALLOWED_UPDATES,
   })
   console.log(`Webhook set: ${webhookUrl}`)
 } else {
   // Local dev: use long polling
   console.log('Starting long polling...')
-  void bot.start({ allowed_updates: ['message', 'callback_query', 'pre_checkout_query', 'poll', 'poll_answer', 'inline_query', 'my_chat_member'] })
+  void bot.start({ allowed_updates: ALLOWED_UPDATES })
 }

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -13,6 +13,7 @@ import { sessionRoutes } from './routes/sessions'
 import { authRoutes, authOidcRoutes } from './routes/auth.js'
 import { savedRoutesRoutes } from './routes/savedRoutes.js'
 import { userBotRoutesRoutes } from './routes/userBotRoutes.js'
+import { groupRoutesRoutes } from './routes/groupRoutes.js'
 import { graphhopperRoutes } from './routes/graphhopper.js'
 import { webpayRoutes } from './routes/webpay'
 import { cryptopayRoutes } from './routes/cryptopay'
@@ -119,6 +120,7 @@ fastify.register(authOidcRoutes, { prefix: '/auth' })
 fastify.register(authRoutes, { prefix: '/api/auth' })
 fastify.register(savedRoutesRoutes, { prefix: '/api/saved-routes' })
 fastify.register(userBotRoutesRoutes, { prefix: '/api/user-bot-routes' })
+fastify.register(groupRoutesRoutes, { prefix: '/api/group-routes' })
 
 // Payment webhooks
 fastify.register(webpayRoutes)

--- a/packages/bot/src/middleware/auth.ts
+++ b/packages/bot/src/middleware/auth.ts
@@ -43,6 +43,11 @@ export function validateTelegramInitData(initData: string): CallerIdentity {
     throw new AuthError('Invalid initData')
   }
 
+  const authDate = Number(params.get('auth_date') ?? 0)
+  if (Date.now() / 1000 - authDate > 86400) {
+    throw new AuthError('Telegram session expired. Please reopen the app.')
+  }
+
   const userJson = params.get('user')
   if (!userJson) throw new AuthError('Invalid initData: missing user')
 

--- a/packages/bot/src/payments/telegramPayments.ts
+++ b/packages/bot/src/payments/telegramPayments.ts
@@ -142,4 +142,43 @@ export function registerPaymentHandlers(bot: Bot<Context>): void {
       )
     }
   })
+
+  // ── Refund — deactivate subscription ────────────────────────────────────────
+  bot.on('message:refunded_payment', async (ctx) => {
+    const payment = ctx.message.refunded_payment
+    if (!payment) return
+
+    const chatId = BigInt(ctx.chat.id)
+    const chargeId = payment.telegram_payment_charge_id
+
+    try {
+      const sub = await prisma.subscription.findFirst({
+        where: { telegramPaymentChargeId: chargeId },
+      })
+
+      await prisma.$transaction([
+        prisma.subscription.updateMany({
+          where: { telegramPaymentChargeId: chargeId },
+          data: { status: 'refunded' },
+        }),
+        prisma.group.updateMany({ where: { chatId }, data: { isPro: false } }),
+      ])
+
+      // Also revoke the linked group subscription if this was a personal sub
+      if (sub?.linkedGroupChatId) {
+        await prisma.group.updateMany({
+          where: { chatId: sub.linkedGroupChatId },
+          data: { isPro: false },
+        })
+        await prisma.subscription.updateMany({
+          where: { chatId: sub.linkedGroupChatId, status: 'active' },
+          data: { status: 'refunded' },
+        })
+      }
+
+      await ctx.reply('ℹ️ Возврат средств выполнен. Подписка TrailX Pro деактивирована.')
+    } catch (err) {
+      console.error('[payment] Failed to process refund:', err)
+    }
+  })
 }

--- a/packages/bot/src/payments/telegramPayments.ts
+++ b/packages/bot/src/payments/telegramPayments.ts
@@ -1,4 +1,5 @@
 import type { Bot, Context } from 'grammy'
+import { InlineKeyboard } from 'grammy'
 import { prisma } from '../db'
 import { calcExpiresAt, isPlanId } from './plans'
 import { getPlanSafe } from '../services/pricing'
@@ -112,6 +113,27 @@ export function registerPaymentHandlers(bot: Bot<Context>): void {
         `Теперь доступны все групповые функции: /add, /vote, /gpx, /weather.`,
         { parse_mode: 'HTML' },
       )
+
+      // If purchased in a private chat — offer to transfer to a group
+      const isPrivateChat = chatId === BigInt(ctx.from.id)
+      if (isPrivateChat) {
+        const kb = new InlineKeyboard().switchInlineChosen(
+          '👥 Активировать для группы',
+          {
+            query: `transfer:${ctx.from.id}:${planId}`,
+            allow_group_chats: true,
+            allow_channel_chats: false,
+            allow_user_chats: false,
+            allow_bot_chats: false,
+          },
+        )
+        await ctx.reply(
+          '💡 <b>Подписка привязана к твоему личному чату.</b>\n\n' +
+          'Хочешь передать её в один из групповых чатов? ' +
+          'После передачи группа получит Pro-доступ, а личный чат — нет.',
+          { parse_mode: 'HTML', reply_markup: kb },
+        )
+      }
     } catch (err) {
       console.error('[payment] Failed to activate subscription:', err)
       await ctx.reply(

--- a/packages/bot/src/routes/auth.ts
+++ b/packages/bot/src/routes/auth.ts
@@ -37,7 +37,7 @@ function toAuthUser(user: {
 }): AuthUser {
   return {
     id: user.id,
-    telegramId: Number(user.telegramId),
+    telegramId: user.telegramId.toString(),
     name: user.name ?? '',
     username: user.username ?? undefined,
     avatarUrl: user.avatarUrl ?? undefined,

--- a/packages/bot/src/routes/groupRoutes.ts
+++ b/packages/bot/src/routes/groupRoutes.ts
@@ -46,9 +46,11 @@ function toDTO(
 
 export const groupRoutesRoutes: FastifyPluginAsync = async (fastify) => {
   // GET /api/group-routes — all routes from groups the user belongs to
-  fastify.get('/', async (req, reply) => {
+  fastify.get<{ Querystring: { limit?: string; offset?: string } }>('/', async (req, reply) => {
     try {
       const telegramId = await resolveTelegramId(req)
+      const limit = Math.min(Number(req.query.limit ?? 20), 50)
+      const offset = Number(req.query.offset ?? 0)
 
       // Find all groups this user is a member of
       const memberships = await prisma.groupMember.findMany({
@@ -65,7 +67,8 @@ export const groupRoutesRoutes: FastifyPluginAsync = async (fastify) => {
       const routes = await prisma.route.findMany({
         where: { groupId: { in: groupIds } },
         orderBy: { updatedAt: 'desc' },
-        take: 50,
+        take: limit,
+        skip: offset,
         select: {
           id: true,
           name: true,

--- a/packages/bot/src/routes/groupRoutes.ts
+++ b/packages/bot/src/routes/groupRoutes.ts
@@ -1,0 +1,89 @@
+import type { FastifyPluginAsync, FastifyRequest } from 'fastify'
+import { prisma } from '../db.js'
+import { AuthError, validateTelegramInitData } from '../middleware/auth.js'
+import { resolveSessionIdentity } from '../middleware/sessionAuth.js'
+import type { GroupRouteDTO } from '@trailx/shared'
+import type { Prisma } from '@prisma/client'
+
+async function resolveTelegramId(req: FastifyRequest): Promise<bigint> {
+  const initData = req.headers['x-telegram-initdata']
+  if (typeof initData === 'string' && initData) {
+    const identity = validateTelegramInitData(initData)
+    return identity.telegramUserId!
+  }
+  const { telegramId } = await resolveSessionIdentity(req)
+  return telegramId
+}
+
+function toDTO(
+  route: {
+    id: string
+    name: string | null
+    waypoints: Prisma.JsonValue
+    distanceKm: number | null
+    elevationM: number | null
+    groupId: string
+    creatorTelegramId: bigint | null
+    createdAt: Date
+    updatedAt: Date
+    group: { chatId: bigint }
+  },
+  telegramId: bigint,
+): GroupRouteDTO {
+  return {
+    id: route.id,
+    name: route.name ?? '',
+    waypoints: route.waypoints as unknown[],
+    distanceKm: route.distanceKm,
+    elevationM: route.elevationM,
+    groupId: route.groupId,
+    groupChatId: route.group.chatId.toString(),
+    isOwner: route.creatorTelegramId === telegramId,
+    createdAt: route.createdAt.toISOString(),
+    updatedAt: route.updatedAt.toISOString(),
+  }
+}
+
+export const groupRoutesRoutes: FastifyPluginAsync = async (fastify) => {
+  // GET /api/group-routes — all routes from groups the user belongs to
+  fastify.get('/', async (req, reply) => {
+    try {
+      const telegramId = await resolveTelegramId(req)
+
+      // Find all groups this user is a member of
+      const memberships = await prisma.groupMember.findMany({
+        where: { telegramId, status: { notIn: ['left', 'kicked'] } },
+        select: { groupId: true },
+      })
+
+      if (memberships.length === 0) {
+        return reply.send([])
+      }
+
+      const groupIds = memberships.map((m) => m.groupId)
+
+      const routes = await prisma.route.findMany({
+        where: { groupId: { in: groupIds } },
+        orderBy: { updatedAt: 'desc' },
+        take: 50,
+        select: {
+          id: true,
+          name: true,
+          waypoints: true,
+          distanceKm: true,
+          elevationM: true,
+          groupId: true,
+          creatorTelegramId: true,
+          createdAt: true,
+          updatedAt: true,
+          group: { select: { chatId: true } },
+        },
+      })
+
+      return reply.send(routes.map((r) => toDTO(r, telegramId)))
+    } catch (err) {
+      if (err instanceof AuthError) return reply.code(401).send({ error: err.message })
+      throw err
+    }
+  })
+}

--- a/packages/bot/src/routes/userBotRoutes.ts
+++ b/packages/bot/src/routes/userBotRoutes.ts
@@ -2,6 +2,7 @@ import type { FastifyPluginAsync, FastifyRequest } from 'fastify'
 import { prisma } from '../db.js'
 import { AuthError, validateTelegramInitData } from '../middleware/auth.js'
 import { resolveSessionIdentity } from '../middleware/sessionAuth.js'
+import { broadcastRouteUpdate } from '../ws/hub.js'
 import type { BotRouteDTO } from '@trailx/shared'
 import type { Prisma } from '@prisma/client'
 
@@ -38,6 +39,7 @@ function toDTO(route: {
 }
 
 export const userBotRoutesRoutes: FastifyPluginAsync = async (fastify) => {
+  // GET /api/user-bot-routes — own bot routes
   fastify.get('/', async (req, reply) => {
     try {
       const telegramId = await resolveTelegramId(req)
@@ -57,6 +59,85 @@ export const userBotRoutesRoutes: FastifyPluginAsync = async (fastify) => {
         },
       })
       return reply.send(routes.map(toDTO))
+    } catch (err) {
+      if (err instanceof AuthError) return reply.code(401).send({ error: err.message })
+      throw err
+    }
+  })
+
+  // PATCH /api/user-bot-routes/:id — update name and/or waypoints
+  fastify.patch<{ Params: { id: string }; Body: { name?: string; waypoints?: unknown[] } }>(
+    '/:id',
+    async (req, reply) => {
+      try {
+        const telegramId = await resolveTelegramId(req)
+        const route = await prisma.route.findUnique({
+          where: { id: req.params.id },
+          select: { creatorTelegramId: true, groupId: true, group: { select: { chatId: true } } },
+        })
+        if (!route) return reply.code(404).send({ error: 'Not found' })
+        if (route.creatorTelegramId !== telegramId) return reply.code(403).send({ error: 'Forbidden' })
+
+        const { name, waypoints } = req.body
+        const data: Prisma.RouteUpdateInput = {}
+        if (name !== undefined) data.name = name.trim()
+        if (waypoints !== undefined) data.waypoints = waypoints as Prisma.InputJsonValue
+
+        const updated = await prisma.route.update({
+          where: { id: req.params.id },
+          data,
+          select: {
+            id: true,
+            name: true,
+            waypoints: true,
+            distanceKm: true,
+            elevationM: true,
+            groupId: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        })
+
+        // Broadcast real-time update if waypoints changed
+        if (waypoints !== undefined) {
+          broadcastRouteUpdate(
+            route.group.chatId.toString(),
+            req.params.id,
+            waypoints as Array<{ lat: number; lng: number; label?: string; order: number }>,
+          )
+        }
+
+        return reply.send(toDTO(updated))
+      } catch (err) {
+        if (err instanceof AuthError) return reply.code(401).send({ error: err.message })
+        throw err
+      }
+    },
+  )
+
+  // DELETE /api/user-bot-routes/:id — delete own bot route
+  fastify.delete<{ Params: { id: string } }>('/:id', async (req, reply) => {
+    try {
+      const telegramId = await resolveTelegramId(req)
+      const route = await prisma.route.findUnique({
+        where: { id: req.params.id },
+        select: { creatorTelegramId: true, groupId: true, group: { select: { id: true, activeRouteId: true } } },
+      })
+      if (!route) return reply.code(404).send({ error: 'Not found' })
+      if (route.creatorTelegramId !== telegramId) return reply.code(403).send({ error: 'Forbidden' })
+
+      await prisma.$transaction(async (tx) => {
+        // Clear activeRouteId if it points to this route
+        if (route.group.activeRouteId === req.params.id) {
+          await tx.group.update({
+            where: { id: route.group.id },
+            data: { activeRouteId: null },
+          })
+        }
+        await tx.route.delete({ where: { id: req.params.id } })
+      })
+
+      return reply.code(204).send()
     } catch (err) {
       if (err instanceof AuthError) return reply.code(401).send({ error: err.message })
       throw err

--- a/packages/bot/src/routes/userBotRoutes.ts
+++ b/packages/bot/src/routes/userBotRoutes.ts
@@ -40,13 +40,16 @@ function toDTO(route: {
 
 export const userBotRoutesRoutes: FastifyPluginAsync = async (fastify) => {
   // GET /api/user-bot-routes — own bot routes
-  fastify.get('/', async (req, reply) => {
+  fastify.get<{ Querystring: { limit?: string; offset?: string } }>('/', async (req, reply) => {
     try {
       const telegramId = await resolveTelegramId(req)
+      const limit = Math.min(Number(req.query.limit ?? 20), 50)
+      const offset = Number(req.query.offset ?? 0)
       const routes = await prisma.route.findMany({
         where: { creatorTelegramId: telegramId },
         orderBy: { updatedAt: 'desc' },
-        take: 20,
+        take: limit,
+        skip: offset,
         select: {
           id: true,
           name: true,
@@ -79,6 +82,17 @@ export const userBotRoutesRoutes: FastifyPluginAsync = async (fastify) => {
         if (route.creatorTelegramId !== telegramId) return reply.code(403).send({ error: 'Forbidden' })
 
         const { name, waypoints } = req.body
+
+        if (waypoints !== undefined) {
+          const valid = Array.isArray(waypoints) &&
+            waypoints.every((w: unknown) => {
+              const wp = w as Record<string, unknown>
+              return typeof wp.lat === 'number' && typeof wp.lng === 'number' &&
+                     wp.lat >= -90 && wp.lat <= 90 && wp.lng >= -180 && wp.lng <= 180
+            })
+          if (!valid) return reply.code(400).send({ error: 'Invalid waypoints' })
+        }
+
         const data: Prisma.RouteUpdateInput = {}
         if (name !== undefined) data.name = name.trim()
         if (waypoints !== undefined) data.waypoints = waypoints as Prisma.InputJsonValue

--- a/packages/bot/src/services/geocode.ts
+++ b/packages/bot/src/services/geocode.ts
@@ -1,17 +1,4 @@
-const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org'
-const NOMINATIM_EMAIL = 'trailx@app'
-
-// 1 req/sec throttle per Nominatim usage policy
-let lastCallTime = 0
-
-function throttledFetch(url: string): Promise<Response> {
-  const now = Date.now()
-  const wait = Math.max(0, lastCallTime + 1000 - now)
-  lastCallTime = now + wait
-  return new Promise((resolve, reject) =>
-    setTimeout(() => fetch(url).then(resolve, reject), wait),
-  )
-}
+const PHOTON_BASE = 'https://photon.komoot.io'
 
 export interface GeocodedPlace {
   lat: number
@@ -24,45 +11,50 @@ interface Waypoint {
   lng: number
 }
 
-interface NominatimResult {
-  lat: string
-  lon: string
-  display_name: string
-  address?: Partial<Record<string, string>>
+interface PhotonProperties {
+  name?: string
+  street?: string
+  housenumber?: string
+  city?: string
+  town?: string
+  village?: string
+  county?: string
+  country?: string
+  type?: string
 }
 
-function buildLabel(result: NominatimResult): string {
-  const a = result.address
-  if (!a) return result.display_name.split(',').slice(0, 2).join(',').trim()
+interface PhotonFeature {
+  geometry: { coordinates: [number, number] }
+  properties: PhotonProperties
+}
 
-  const city = a.city ?? a.town ?? a.village ?? a.suburb ?? a.municipality
-  const poi = a.name ?? a.amenity ?? a.tourism ?? a.leisure ?? a.natural
+interface PhotonResponse {
+  features: PhotonFeature[]
+}
 
-  if (poi) {
-    const road = a.road ?? a.pedestrian ?? a.footway
-    const streetHint = road
-      ? a.house_number
-        ? `${road} ${a.house_number}`
-        : road
-      : null
-    const context = [streetHint, city].filter(Boolean).join(', ')
+function buildLabel(p: PhotonProperties): string {
+  const poi = p.name
+  const road = p.street
+  const house = p.housenumber
+  const city = p.city ?? p.town ?? p.village ?? p.county
+
+  if (poi && poi !== road) {
+    const streetPart = road ? (house ? `${road} ${house}` : road) : null
+    const context = [streetPart, city].filter(Boolean).join(', ')
     return context ? `${poi} — ${context}` : poi
   }
 
-  const road = a.road ?? a.pedestrian ?? a.footway ?? a.cycleway ?? a.path
   if (road) {
-    const streetAddr = a.house_number ? `${road} ${a.house_number}` : road
+    const streetAddr = house ? `${road} ${house}` : road
     return city ? `${streetAddr}, ${city}` : streetAddr
   }
 
-  return result.display_name.split(',').slice(0, 2).join(',').trim()
+  return city ?? p.country ?? 'Unknown'
 }
 
 /**
- * Search for places using Nominatim.
- * If routeWaypoints are provided, applies a soft geographic bias toward the
- * route's bounding box (results outside the box are still returned if nothing
- * is found inside).
+ * Forward geocoding via Photon (Komoot).
+ * If routeWaypoints provided, applies a bbox soft bias.
  */
 export async function geocode(
   query: string,
@@ -71,37 +63,61 @@ export async function geocode(
   if (!query.trim()) return []
 
   const params = new URLSearchParams({
-    format: 'json',
     q: query.trim(),
+    lang: 'ru',
     limit: '5',
-    'accept-language': 'ru,en',
-    email: NOMINATIM_EMAIL,
-    addressdetails: '1',
   })
 
   if (routeWaypoints && routeWaypoints.length > 0) {
     const lats = routeWaypoints.map((w) => w.lat)
     const lngs = routeWaypoints.map((w) => w.lng)
-    const pad = 0.05 // ~5 km
-    const minLng = Math.min(...lngs) - pad
-    const minLat = Math.min(...lats) - pad
-    const maxLng = Math.max(...lngs) + pad
-    const maxLat = Math.max(...lats) + pad
-    // Nominatim viewbox: left(minLng), top(maxLat), right(maxLng), bottom(minLat)
-    params.set('viewbox', `${minLng},${maxLat},${maxLng},${minLat}`)
-    params.set('bounded', '0') // soft bias — still return results outside box
+    const pad = 0.05
+    params.set('bbox', [
+      Math.min(...lngs) - pad,
+      Math.min(...lats) - pad,
+      Math.max(...lngs) + pad,
+      Math.max(...lats) + pad,
+    ].join(','))
   }
 
   try {
-    const res = await throttledFetch(`${NOMINATIM_BASE}/search?${params}`)
-    if (!res.ok) return []
-    const results = (await res.json()) as NominatimResult[]
-    return results.map((r) => ({
-      lat: parseFloat(r.lat),
-      lng: parseFloat(r.lon),
-      name: buildLabel(r),
+    const res = await fetch(`${PHOTON_BASE}/api/?${params}`)
+    if (!res.ok) {
+      console.error('[geocode] Photon returned', res.status)
+      return []
+    }
+    const data = (await res.json()) as PhotonResponse
+    return data.features.map((f) => ({
+      lat: f.geometry.coordinates[1],
+      lng: f.geometry.coordinates[0],
+      name: buildLabel(f.properties),
     }))
-  } catch {
+  } catch (err) {
+    console.error('[geocode] Photon fetch error:', err)
     return []
+  }
+}
+
+/**
+ * Reverse geocoding via Photon — returns a short human-readable label.
+ */
+export async function reverseGeocode(lat: number, lng: number): Promise<string | null> {
+  try {
+    const params = new URLSearchParams({
+      lat: String(lat),
+      lon: String(lng),
+      lang: 'ru',
+    })
+    const res = await fetch(`${PHOTON_BASE}/reverse?${params}`)
+    if (!res.ok) {
+      console.error('[reverseGeocode] Photon returned', res.status)
+      return null
+    }
+    const data = (await res.json()) as PhotonResponse
+    if (!data.features.length) return null
+    return buildLabel(data.features[0].properties)
+  } catch (err) {
+    console.error('[reverseGeocode] Photon fetch error:', err)
+    return null
   }
 }

--- a/packages/bot/src/services/pricing.ts
+++ b/packages/bot/src/services/pricing.ts
@@ -22,6 +22,7 @@ export interface Plan {
   label: string
   description: string
   days: number
+  priceDisplay?: string // ориентировочная цена для UI, например "$5"
   isActive: boolean
   sortOrder: number
 }
@@ -162,6 +163,7 @@ export const FALLBACK_PLANS: Plan[] = [
     label: '1 месяц',
     description: 'TrailX Pro — доступ к групповым маршрутам, командам бота и синхронизации в реальном времени.',
     days: 30,
+    priceDisplay: '$5',
     isActive: true,
     sortOrder: 1,
   },
@@ -170,6 +172,7 @@ export const FALLBACK_PLANS: Plan[] = [
     label: '1 год',
     description: 'TrailX Pro на 12 месяцев — экономия 25% по сравнению с ежемесячной оплатой.',
     days: 365,
+    priceDisplay: '$45',
     isActive: true,
     sortOrder: 2,
   },

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -42,3 +42,8 @@ export interface BotRouteDTO {
   createdAt: string
   updatedAt: string
 }
+
+export interface GroupRouteDTO extends BotRouteDTO {
+  groupChatId: string
+  isOwner: boolean
+}

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -1,6 +1,6 @@
 export interface AuthUser {
   id: string
-  telegramId: number
+  telegramId: string
   name: string
   username?: string
   avatarUrl?: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@fastify/cors':
         specifier: ^9.0.1
         version: 9.0.1
+      '@fastify/rate-limit':
+        specifier: ^10.3.0
+        version: 10.3.0
       '@fastify/websocket':
         specifier: ^10.0.1
         version: 10.0.1
@@ -561,6 +564,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
+  '@fastify/rate-limit@10.3.0':
+    resolution: {integrity: sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==}
+
   '@fastify/websocket@10.0.1':
     resolution: {integrity: sha512-8/pQIxTPRD8U94aILTeJ+2O3el/r19+Ej5z1O1mXlqplsUH7KzCjAI0sgd5DM/NoPjAi5qLFNIjgM5+9/rGSNw==}
 
@@ -598,6 +604,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
 
   '@mapbox/jsonlint-lines-primitives@2.0.2':
     resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
@@ -1871,6 +1881,9 @@ packages:
 
   fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
+
+  fastify-plugin@5.1.0:
+    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
   fastify-raw-body@4.3.0:
     resolution: {integrity: sha512-F4o8ZIMVx4YoxGfwrZys6wyjl40gF3Yv6AWWRy62ozFAyZBSS831/uyyCAqKYw3tR73g180ryG98yih6To1PUQ==}
@@ -3367,6 +3380,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@fastify/rate-limit@10.3.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      fastify-plugin: 5.1.0
+      toad-cache: 3.7.0
+
   '@fastify/websocket@10.0.1':
     dependencies:
       duplexify: 4.1.3
@@ -3407,6 +3426,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lukeed/ms@2.0.2': {}
 
   '@mapbox/jsonlint-lines-primitives@2.0.2': {}
 
@@ -4726,6 +4747,8 @@ snapshots:
   fast-uri@3.1.0: {}
 
   fastify-plugin@4.5.1: {}
+
+  fastify-plugin@5.1.0: {}
 
   fastify-raw-body@4.3.0:
     dependencies:

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "buildCommand": "pnpm install --frozen-lockfile && pnpm --filter=@trailx/bot exec prisma generate && pnpm turbo build --filter=@trailx/bot..."
   },
   "deploy": {
-    "startCommand": "node --import ./packages/bot/dist/instrument.js packages/bot/dist/index.js",
+    "startCommand": "pnpm --filter=@trailx/bot exec prisma migrate deploy && node --import ./packages/bot/dist/instrument.js packages/bot/dist/index.js",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
## Summary
This PR introduces several major features and improvements: migrates from Nominatim to Photon for geocoding, implements subscription transfer to groups, adds group route management APIs, and improves the free-tier experience with coordinate input support.

## Key Changes

### Geocoding Migration (Nominatim → Photon)
- Replaced Nominatim API with Photon (Komoot) for forward and reverse geocoding
- Removed throttling logic (Photon has more generous rate limits)
- Simplified label building to work with Photon's property structure
- Added new `reverseGeocode()` function for coordinate-to-label conversion
- Updated language parameter to `lang: ru` and removed email requirement

### Subscription Transfer to Groups
- Added `linkedGroupChatId` field to Subscription model to track personal→group transfers
- Implemented "COPY" model: personal subscription remains active, group gets a linked copy with same expiry
- Added `confirm_transfer` callback handler in upgrade command to activate subscriptions in group context
- Added inline query support for subscription transfer via `transfer:{userId}:{planId}` format
- Added refund handler to deactivate both personal and linked group subscriptions

### Group Routes & Membership Tracking
- Created new `GroupMember` model to track user membership in groups
- Added `groupRoutes` API endpoint (`GET /api/group-routes`) to list routes from user's groups
- Added `upsertGroupMember()` helper to track group membership on user interactions
- Implemented middleware to capture group membership on every message/callback
- Added `chat_member` event handler to track join/leave/kick status changes

### User Bot Routes API Enhancements
- Added pagination support (`limit`, `offset` query params) to `GET /api/user-bot-routes`
- Implemented `PATCH /api/user-bot-routes/:id` to update route name and waypoints
- Implemented `DELETE /api/user-bot-routes/:id` to delete routes
- Added real-time WebSocket broadcast on waypoint updates

### Free-Tier Improvements
- Added free-tier limit (3 waypoints) with Pro upgrade prompt
- Implemented coordinate input shortcut: `/add 52.0977 23.7341` to add points directly
- Uses reverse geocoding to generate human-readable labels for coordinate inputs
- Removed `requireSubscription` middleware from `/add` command

### UI & API Updates
- Added `GroupRouteDTO` type for group routes in shared types
- Updated `useSavedRoutes` hook to load and manage group routes
- Changed `telegramId` type from `number` to `string` across auth types
- Added `priceDisplay` field to Plan model for UI pricing hints
- Simplified plan keyboard generation to use `plan.priceDisplay`

### Infrastructure
- Added `@fastify/rate-limit` for API rate limiting (60 req/min per user)
- Rate limiting uses Telegram initData hash or IP as key
- Added subscription expiry reminder (7 days before expiration)
- Improved error logging in geocoding and payment handlers

## Notable Implementation Details
- Subscription transfer uses database transaction to ensure atomicity
- Group membership tracking uses upsert to avoid duplicates on repeated interactions
- Coordinate validation ensures lat ∈ [-90, 90] and lng ∈ [-180, 180]
- Refund handler cascades to revoke linked group subscriptions
- Real-time route updates broadcast to group WebSocket connections

https://claude.ai/code/session_01PcW1hPJk4jfd5knFgDCrjx