### PR TITLE
fix(db): add migration for Subscription.linkedGroupChatId column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ desktop.ini
 # Optional: Database
 *.dump
 *.sql
+!packages/bot/prisma/migrations/**/*.sql
 dump.rdb
 *.db
 *.sqlite

--- a/packages/bot/prisma/migrations/20260430000000_add_linked_group_chat_id/migration.sql
+++ b/packages/bot/prisma/migrations/20260430000000_add_linked_group_chat_id/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Subscription" ADD COLUMN "linkedGroupChatId" BIGINT;


### PR DESCRIPTION
The column was added to the Prisma schema in b074b35 but the migration
file was never created, causing P2022 errors on every /upgrade invocation.

Also unblocks *.sql files under prisma/migrations/ in .gitignore so
future migration files are tracked in git.

Manual fix: ALTER TABLE "Subscription" ADD COLUMN "linkedGroupChatId" BIGINT;

https://claude.ai/code/session_01WNKAD5Wfva9a88HaNizvWJ