### PR TITLE
fix(db): add missing migrations for Subscription and GroupMember

### DIFF
--- a/packages/bot/prisma/migrations/20260430000000_add_linked_group_chat_id/migration.sql
+++ b/packages/bot/prisma/migrations/20260430000000_add_linked_group_chat_id/migration.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "Subscription" ADD COLUMN "linkedGroupChatId" BIGINT;
+ALTER TABLE "Subscription" ADD COLUMN IF NOT EXISTS "linkedGroupChatId" BIGINT;

--- a/packages/bot/prisma/migrations/20260430120000_add_missing_schema_fields/migration.sql
+++ b/packages/bot/prisma/migrations/20260430120000_add_missing_schema_fields/migration.sql
@@ -1,0 +1,23 @@
+-- Add missing columns to Subscription
+ALTER TABLE "Subscription"
+  ADD COLUMN IF NOT EXISTS "reminderSentAt" TIMESTAMP(3);
+
+-- Add missing column to Plan
+ALTER TABLE "Plan"
+  ADD COLUMN IF NOT EXISTS "priceDisplay" TEXT;
+
+-- Create GroupMember table
+CREATE TABLE IF NOT EXISTS "GroupMember" (
+  "id"         TEXT NOT NULL,
+  "groupId"    TEXT NOT NULL,
+  "telegramId" BIGINT NOT NULL,
+  "status"     TEXT NOT NULL DEFAULT 'member',
+  "updatedAt"  TIMESTAMP(3) NOT NULL,
+  "createdAt"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "GroupMember_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "GroupMember_groupId_fkey" FOREIGN KEY ("groupId")
+    REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "GroupMember_groupId_telegramId_key" UNIQUE ("groupId", "telegramId")
+);
+
+CREATE INDEX IF NOT EXISTS "GroupMember_telegramId_idx" ON "GroupMember"("telegramId");


### PR DESCRIPTION
## Problem

Three schema fields were added to `schema.prisma` in previous commits but migration files were never created. This caused `P2022`/`P2021` errors on every `/upgrade` command:

- `Subscription.linkedGroupChatId` — P2022
- `Subscription.reminderSentAt` — P2022  
- `GroupMember` table — P2021 (table doesn't exist)
- `Plan.priceDisplay` — would also fail once the above are fixed

Also fixed: `*.sql` files under `prisma/migrations/` were blocked by `.gitignore`, preventing migration files from being committed at all.

## Changes

- `.gitignore`: add exception `!packages/bot/prisma/migrations/**/*.sql`
- `20260430000000_add_linked_group_chat_id/migration.sql`: adds `Subscription.linkedGroupChatId`
- `20260430120000_add_missing_schema_fields/migration.sql`: adds `Subscription.reminderSentAt`, `Plan.priceDisplay`, creates `GroupMember` table with index

All statements use `IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS` — safe to apply even if some columns were already added manually.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNKAD5Wfva9a88HaNizvWJ)_